### PR TITLE
Fix bug with AMI ID

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -135,7 +135,7 @@ module "clients" {
   max_size         = "${var.num_clients}"
   desired_capacity = "${var.num_clients}"
 
-  ami_id    = "${var.ami_id}"
+  ami_id    = "${var.ami_id == "" ? data.aws_ami.nomad_consul.image_id : var.ami_id}"
   user_data = "${data.template_file.user_data_client.rendered}"
 
   vpc_id     = "${data.aws_vpc.default.id}"


### PR DESCRIPTION
In the example code, we leave the `ami_id` param blank by default and fetch our public images to make it easier to get started. In one place, we forgot to swap in the public image, so we were trying to use a blank `ami_id` value.