### PR TITLE
Configurable instance type

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -127,7 +127,7 @@ module "clients" {
   source = "./modules/nomad-cluster"
 
   cluster_name  = "${var.cluster_name}-client"
-  instance_type = "t2.micro"
+  instance_type = "${var.instance_type}"
 
   # To keep the example simple, we are using a fixed-size cluster. In real-world usage, you could use auto scaling
   # policies to dynamically resize the cluster in response to load.

--- a/variables.tf
+++ b/variables.tf
@@ -33,6 +33,11 @@ variable "cluster_name" {
   default     = "nomad-example"
 }
 
+variable "instance_type" {
+   description = "What kind of instance type to use for the nomad clients"
+   default     = "t2.micro"
+}
+
 variable "num_servers" {
   description = "The number of server nodes to deploy. We strongly recommend using 3 or 5."
   default     = 3


### PR DESCRIPTION
Currently the instance type is not configurable from the 'top-level' module. So when instantiating they default to the standard t2.micro. Since they have very little memory, they are not really feasible for the job.