### PR TITLE
Feature/upgrade versions Nomad, Consul

### DIFF
--- a/examples/nomad-consul-ami/nomad-consul-docker.json
+++ b/examples/nomad-consul-ami/nomad-consul-docker.json
@@ -2,9 +2,9 @@
   "min_packer_version": "0.12.0",
   "variables": {
     "aws_region": "us-east-1",
-    "nomad_version": "0.6.3",
-    "consul_module_version": "v0.0.3",
-    "consul_version": "0.9.3"
+    "nomad_version": "0.7.1",
+    "consul_module_version": "v0.1.0",
+    "consul_version": "1.0.3"
   },
   "builders": [
     {

--- a/examples/nomad-consul-ami/nomad-consul.json
+++ b/examples/nomad-consul-ami/nomad-consul.json
@@ -2,9 +2,9 @@
   "min_packer_version": "0.12.0",
   "variables": {
     "aws_region": "us-east-1",
-    "nomad_version": "0.6.3",
-    "consul_module_version": "v0.0.3",
-    "consul_version": "0.9.3"
+    "nomad_version": "0.7.1",
+    "consul_module_version": "v0.1.0",
+    "consul_version": "1.0.3"
   },
   "builders": [
     {

--- a/examples/nomad-consul-separate-cluster/main.tf
+++ b/examples/nomad-consul-separate-cluster/main.tf
@@ -66,7 +66,7 @@ data "aws_ami" "nomad_consul" {
 module "nomad_servers" {
   # When using these modules in your own templates, you will need to use a Git URL with a ref attribute that pins you
   # to a specific version of the modules, such as the following example:
-  # source = "git::git@github.com:hashicorp/terraform-aws-nomad.git//modules/nomad-cluster?ref=v0.0.1"
+  # source = "git::git@github.com:hashicorp/terraform-aws-nomad.git//modules/nomad-cluster?ref=v0.1.0"
   source = "../../modules/nomad-cluster"
 
   cluster_name  = "${var.nomad_cluster_name}-server"
@@ -97,7 +97,7 @@ module "nomad_servers" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 module "consul_iam_policies_servers" {
-  source = "git::git@github.com:hashicorp/terraform-aws-consul.git//modules/consul-iam-policies?ref=v0.0.3"
+  source = "git::git@github.com:hashicorp/terraform-aws-consul.git//modules/consul-iam-policies?ref=v0.1.0"
 
   iam_role_id = "${module.nomad_servers.iam_role_id}"
 }
@@ -122,7 +122,7 @@ data "template_file" "user_data_nomad_server" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 module "consul_servers" {
-  source = "git::git@github.com:hashicorp/terraform-aws-consul.git//modules/consul-cluster?ref=v0.0.3"
+  source = "git::git@github.com:hashicorp/terraform-aws-consul.git//modules/consul-cluster?ref=v0.1.0"
 
   cluster_name  = "${var.consul_cluster_name}-server"
   cluster_size  = "${var.num_consul_servers}"
@@ -198,7 +198,7 @@ module "nomad_clients" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 module "consul_iam_policies_clients" {
-  source = "git::git@github.com:hashicorp/terraform-aws-consul.git//modules/consul-iam-policies?ref=v0.0.3"
+  source = "git::git@github.com:hashicorp/terraform-aws-consul.git//modules/consul-iam-policies?ref=v0.1.0"
 
   iam_role_id = "${module.nomad_clients.iam_role_id}"
 }

--- a/main.tf
+++ b/main.tf
@@ -60,7 +60,7 @@ data "aws_ami" "nomad_consul" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 module "servers" {
-  source = "git::git@github.com:hashicorp/terraform-aws-consul.git//modules/consul-cluster?ref=v0.0.3"
+  source = "git::git@github.com:hashicorp/terraform-aws-consul.git//modules/consul-cluster?ref=v0.1.0"
 
   cluster_name  = "${var.cluster_name}-server"
   cluster_size  = "${var.num_servers}"
@@ -155,7 +155,7 @@ module "clients" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 module "consul_iam_policies" {
-  source = "git::git@github.com:hashicorp/terraform-aws-consul.git//modules/consul-iam-policies?ref=v0.0.3"
+  source = "git::git@github.com:hashicorp/terraform-aws-consul.git//modules/consul-iam-policies?ref=v0.1.0"
 
   iam_role_id = "${module.clients.iam_role_id}"
 }


### PR DESCRIPTION
Upgrade versions of nomad and consul used in the repository and in the examples.

**Version Upgrade:**
- nomad: 0.6.3 -> 0.7.1
- consul: 0.9.3 -> 1.0.3
- consul terraform module: 0.0.3 -> 0.1.0

**Tests:**
- Running packer build for `nomad-consul-docker` ( Amazon Linux and Ubuntu )
   - `nomad-consul` without Docker support can be considered a subset.
- Running test deployment of `examples/nomad-consul-separate-cluster`
   - Checked connection of consul server and agents
   - Checked nomad status after terraform deployment
   - Checked deployment and functionality of the cluster with an example service job, not just the default batch job.
=> Everything kept working as it did before.