### PR TITLE
Updated packer documentation and removed file provisioner for git clone

### DIFF
--- a/examples/nomad-consul-ami/README.md
+++ b/examples/nomad-consul-ami/README.md
@@ -1,18 +1,18 @@
 # Nomad and Consul AMI
 
-This folder shows an example of how to use the [install-nomad module](https://github.com/hashicorp/terraform-aws-nomad/tree/master/modules/install-nomad) from this Module and 
+This folder shows an example of how to use the [install-nomad module](https://github.com/hashicorp/terraform-aws-nomad/tree/master/modules/install-nomad) from this Module and
 the [install-consul module](https://github.com/hashicorp/terraform-aws-consul/tree/master/modules/install-consul)
-from the Consul AWS Module with [Packer](https://www.packer.io/) to create [Amazon Machine Images 
+from the Consul AWS Module with [Packer](https://www.packer.io/) to create [Amazon Machine Images
 (AMIs)](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AMIs.html) that have Nomad and Consul installed on top of:
- 
+
 1. Ubuntu 16.04
 1. Amazon Linux
 
-These AMIs will have [Consul](https://www.consul.io/) and [Nomad](https://www.nomadproject.io/) installed and 
+These AMIs will have [Consul](https://www.consul.io/) and [Nomad](https://www.nomadproject.io/) installed and
 configured to automatically join a cluster during boot-up.
 
-To see how to deploy this AMI, check out the [nomad-consul-colocated-cluster 
-example](https://github.com/hashicorp/terraform-aws-nomad/tree/master/MAIN.md). For more info on Nomad installation and configuration, check out 
+To see how to deploy this AMI, check out the [nomad-consul-colocated-cluster
+example](https://github.com/hashicorp/terraform-aws-nomad/tree/master/MAIN.md). For more info on Nomad installation and configuration, check out
 the [install-nomad](https://github.com/hashicorp/terraform-aws-nomad/tree/master/modules/install-nomad) documentation.
 
 
@@ -23,58 +23,15 @@ To build the Nomad and Consul AMI:
 
 1. `git clone` this repo to your computer.
 1. Install [Packer](https://www.packer.io/).
-1. Configure your AWS credentials using one of the [options supported by the AWS 
+1. Configure your AWS credentials using one of the [options supported by the AWS
    SDK](http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html). Usually, the easiest option is to
    set the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables.
-1. Update the `variables` section of the `nomad-consul.json` Packer template to configure the AWS region and Nomad version 
+1. Update the `variables` section of the `nomad-consul.json` Packer template to configure the AWS region and Nomad version
    you wish to use.
 1. Run `packer build nomad-consul.json`.
 
-When the build finishes, it will output the IDs of the new AMIs. To see how to deploy one of these AMIs, check out the 
+When the build finishes, it will output the IDs of the new AMIs. To see how to deploy one of these AMIs, check out the
 [nomad-consul-colocated-cluster example](https://github.com/hashicorp/terraform-aws-nomad/tree/master/MAIN.md).
 
 
 
-
-## Creating your own Packer template for production usage
-
-When creating your own Packer template for production usage, you can copy the example in this folder more or less 
-exactly, except for one change: we recommend replacing the `file` provisioner with a call to `git clone` in the `shell` 
-provisioner. Instead of:
-
-```json
-{
-  "provisioners": [{
-    "type": "file",
-    "source": "{{template_dir}}/../../../terraform-aws-nomad",
-    "destination": "/tmp"
-  },{
-    "type": "shell",
-    "inline": [
-      "/tmp/terraform-aws-nomad/modules/install-nomad/install-nomad --version {{user `nomad_version`}}"
-    ],
-    "pause_before": "30s"
-  }]
-}
-```
-
-Your code should look more like this:
-
-```json
-{
-  "provisioners": [{
-    "type": "shell",
-    "inline": [
-      "git clone --branch <module_VERSION> https://github.com/hashicorp/terraform-aws-nomad.git /tmp/terraform-aws-nomad",
-      "/tmp/terraform-aws-nomad/modules/install-nomad/install-nomad --version {{user `nomad_version`}}"
-    ],
-    "pause_before": "30s"
-  }]
-}
-```
-
-You should replace `<module_VERSION>` in the code above with the version of this module that you want to use (see
-the [Releases Page](../../releases) for all available versions). That's because for production usage, you should always
-use a fixed, known version of this Module, downloaded from the official Git repo. On the other hand, when you're 
-just experimenting with the Module, it's OK to use a local checkout of the Module, uploaded from your own 
-computer.

--- a/examples/nomad-consul-ami/nomad-consul-docker.json
+++ b/examples/nomad-consul-ami/nomad-consul-docker.json
@@ -3,6 +3,7 @@
   "variables": {
     "aws_region": "us-east-1",
     "nomad_version": "0.7.1",
+    "nomad_module_version": "v0.1.0",
     "consul_module_version": "v0.1.0",
     "consul_version": "1.0.3"
   },
@@ -72,7 +73,8 @@
       "environment_vars": [
         "NOMAD_VERSION={{user `nomad_version`}}",
         "CONSUL_VERSION={{user `consul_version`}}",
-        "CONSUL_MODULE_VERSION={{user `consul_module_version`}}"
+        "CONSUL_MODULE_VERSION={{user `consul_module_version`}}",
+        "NOMAD_MODULE_VERSION={{user `nomad_module_version`}}"
       ],
       "script": "{{template_dir}}/setup_nomad_consul.sh"
     }

--- a/examples/nomad-consul-ami/nomad-consul-docker.json
+++ b/examples/nomad-consul-ami/nomad-consul-docker.json
@@ -4,7 +4,7 @@
     "aws_region": "us-east-1",
     "nomad_version": "0.7.1",
     "nomad_module_version": "v0.1.0",
-    "consul_module_version": "v0.1.0",
+    "consul_module_version": "v0.1.1",
     "consul_version": "1.0.3"
   },
   "builders": [

--- a/examples/nomad-consul-ami/nomad-consul-docker.json
+++ b/examples/nomad-consul-ami/nomad-consul-docker.json
@@ -68,12 +68,6 @@
       ]
     },
     {
-      "type": "file",
-      "source": "{{template_dir}}/../../../terraform-aws-nomad",
-      "destination": "/tmp",
-      "pause_before": "30s"
-    },
-    {
       "type": "shell",
       "environment_vars": [
         "NOMAD_VERSION={{user `nomad_version`}}",

--- a/examples/nomad-consul-ami/nomad-consul.json
+++ b/examples/nomad-consul-ami/nomad-consul.json
@@ -72,12 +72,6 @@
       ]
     },
     {
-      "type": "file",
-      "source": "{{template_dir}}/../../../terraform-aws-nomad",
-      "destination": "/tmp",
-      "pause_before": "30s"
-    },
-      {
       "type": "shell",
       "environment_vars": [
         "NOMAD_VERSION={{user `nomad_version`}}",

--- a/examples/nomad-consul-ami/nomad-consul.json
+++ b/examples/nomad-consul-ami/nomad-consul.json
@@ -3,6 +3,7 @@
   "variables": {
     "aws_region": "us-east-1",
     "nomad_version": "0.7.1",
+    "nomad_module_version": "v0.1.0",
     "consul_module_version": "v0.1.0",
     "consul_version": "1.0.3"
   },
@@ -76,7 +77,8 @@
       "environment_vars": [
         "NOMAD_VERSION={{user `nomad_version`}}",
         "CONSUL_VERSION={{user `consul_version`}}",
-        "CONSUL_MODULE_VERSION={{user `consul_module_version`}}"
+        "CONSUL_MODULE_VERSION={{user `consul_module_version`}}",
+        "NOMAD_MODULE_VERSION={{user `nomad_module_version`}}"
       ],
       "script": "{{template_dir}}/setup_nomad_consul.sh"
     }

--- a/examples/nomad-consul-ami/nomad-consul.json
+++ b/examples/nomad-consul-ami/nomad-consul.json
@@ -4,7 +4,7 @@
     "aws_region": "us-east-1",
     "nomad_version": "0.7.1",
     "nomad_module_version": "v0.1.0",
-    "consul_module_version": "v0.1.0",
+    "consul_module_version": "v0.1.1",
     "consul_version": "1.0.3"
   },
   "builders": [

--- a/examples/nomad-consul-ami/setup_nomad_consul.sh
+++ b/examples/nomad-consul-ami/setup_nomad_consul.sh
@@ -2,6 +2,7 @@
 set -e
 
 # Environment variables are set by packer
+git clone --branch "${NOMAD_MODULE_VERSION}" https://github.com/hashicorp/terraform-aws-nomad.git /tmp/terraform-aws-nomad
 /tmp/terraform-aws-nomad/modules/install-nomad/install-nomad --version "${NOMAD_VERSION}"
 
 git clone --branch "${CONSUL_MODULE_VERSION}"  https://github.com/hashicorp/terraform-aws-consul.git /tmp/terraform-aws-consul


### PR DESCRIPTION
Currently busy setting up a new staging cluster, thanks for saving me a bunch of time with this repo :+1:

I noticed the README for the Nomad and Consul AMI example was a bit out of date, specifically the "Creating your own Packer template for production usage" section which was not reflecting the current provisioner step.

To simplify things I changed the file provisioner to instead clone from the nomad module from this github repo, the same way consul is installed. Then I removed that section from the readme because it was no longer needed.

Thougths?
