### PR TITLE
Use `aws_autoscaling_attachment` instead

### DIFF
--- a/modules/nomad-cluster/README.md
+++ b/modules/nomad-cluster/README.md
@@ -1,12 +1,12 @@
 # Nomad Cluster
 
-This folder contains a [Terraform](https://www.terraform.io/) module that can be used to deploy a 
-[Nomad](https://www.nomadproject.io/) cluster in [AWS](https://aws.amazon.com/) on top of an Auto Scaling Group. This 
-module is designed to deploy an [Amazon Machine Image (AMI)](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AMIs.html) 
+This folder contains a [Terraform](https://www.terraform.io/) module that can be used to deploy a
+[Nomad](https://www.nomadproject.io/) cluster in [AWS](https://aws.amazon.com/) on top of an Auto Scaling Group. This
+module is designed to deploy an [Amazon Machine Image (AMI)](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AMIs.html)
 that had Nomad installed via the [install-nomad](https://github.com/hashicorp/terraform-aws-nomad/tree/master/modules/install-nomad) module in this Module.
 
 Note that this module assumes you have a separate [Consul](https://www.consul.io/) cluster already running. If you want
-to run Consul and Nomad in the same cluster, instead of using this module, see the [Deploy Nomad and Consul in the same 
+to run Consul and Nomad in the same cluster, instead of using this module, see the [Deploy Nomad and Consul in the same
 cluster documentation](https://github.com/hashicorp/terraform-aws-nomad/tree/master/README.md#deploy-nomad-and-consul-in-the-same-cluster).
 
 
@@ -24,40 +24,40 @@ module "nomad_cluster" {
 
   # Specify the ID of the Nomad AMI. You should build this using the scripts in the install-nomad module.
   ami_id = "ami-abcd1234"
-  
-  # Configure and start Nomad during boot. It will automatically connect to the Consul cluster specified in its 
-  # configuration and form a cluster with other Nomad nodes connected to that Consul cluster. 
+
+  # Configure and start Nomad during boot. It will automatically connect to the Consul cluster specified in its
+  # configuration and form a cluster with other Nomad nodes connected to that Consul cluster.
   user_data = <<-EOF
               #!/bin/bash
               /opt/nomad/bin/run-nomad --server --num-servers 3
               EOF
-  
+
   # ... See vars.tf for the other parameters you must define for the nomad-cluster module
 }
 ```
 
 Note the following parameters:
 
-* `source`: Use this parameter to specify the URL of the nomad-cluster module. The double slash (`//`) is intentional 
-  and required. Terraform uses it to specify subfolders within a Git repo (see [module 
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in 
-  this repo. That way, instead of using the latest version of this module from the `master` branch, which 
+* `source`: Use this parameter to specify the URL of the nomad-cluster module. The double slash (`//`) is intentional
+  and required. Terraform uses it to specify subfolders within a Git repo (see [module
+  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  this repo. That way, instead of using the latest version of this module from the `master` branch, which
   will change every time you run Terraform, you're using a fixed version of the repo.
 
-* `ami_id`: Use this parameter to specify the ID of a Nomad [Amazon Machine Image 
+* `ami_id`: Use this parameter to specify the ID of a Nomad [Amazon Machine Image
   (AMI)](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AMIs.html) to deploy on each server in the cluster. You
   should install Nomad in this AMI using the scripts in the [install-nomad](https://github.com/hashicorp/terraform-aws-nomad/tree/master/modules/install-nomad) module.
-  
-* `user_data`: Use this parameter to specify a [User 
+
+* `user_data`: Use this parameter to specify a [User
   Data](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/user-data.html#user-data-shell-scripts) script that each
-  server will run during boot. This is where you can use the [run-nomad script](https://github.com/hashicorp/terraform-aws-nomad/tree/master/modules/run-nomad) to configure and 
-  run Nomad. The `run-nomad` script is one of the scripts installed by the [install-nomad](https://github.com/hashicorp/terraform-aws-nomad/tree/master/modules/install-nomad) 
-  module. 
+  server will run during boot. This is where you can use the [run-nomad script](https://github.com/hashicorp/terraform-aws-nomad/tree/master/modules/run-nomad) to configure and
+  run Nomad. The `run-nomad` script is one of the scripts installed by the [install-nomad](https://github.com/hashicorp/terraform-aws-nomad/tree/master/modules/install-nomad)
+  module.
 
 You can find the other parameters in [vars.tf](vars.tf).
 
 Check out the [nomad-consul-separate-cluster example](https://github.com/hashicorp/terraform-aws-nomad/tree/master/examples/nomad-consul-separate-cluster example) for working
-sample code. Note that if you want to run Nomad and Consul on the same cluster, see the [nomad-consul-colocated-cluster 
+sample code. Note that if you want to run Nomad and Consul on the same cluster, see the [nomad-consul-colocated-cluster
 example](https://github.com/hashicorp/terraform-aws-nomad/tree/master/MAIN.md example) instead.
 
 
@@ -68,21 +68,21 @@ example](https://github.com/hashicorp/terraform-aws-nomad/tree/master/MAIN.md ex
 
 ### Using the Node agent from your own computer
 
-If you want to connect to the cluster from your own computer, [install 
+If you want to connect to the cluster from your own computer, [install
 Nomad](https://www.nomadproject.io/docs/install/index.html) and execute commands with the `-address` parameter set to
-the IP address of one of the servers in your Nomad cluster. Note that this only works if the Nomad cluster is running 
-in public subnets and/or your default VPC (as in both [examples](https://github.com/hashicorp/terraform-aws-nomad/tree/master/examples)), which is OK for testing and 
+the IP address of one of the servers in your Nomad cluster. Note that this only works if the Nomad cluster is running
+in public subnets and/or your default VPC (as in both [examples](https://github.com/hashicorp/terraform-aws-nomad/tree/master/examples)), which is OK for testing and
 experimentation, but NOT recommended for production usage.
 
 To use the HTTP API, you first need to get the public IP address of one of the Nomad Instances. If you deployed the
 [nomad-consul-colocated-cluster](https://github.com/hashicorp/terraform-aws-nomad/tree/master/MAIN.md) or
-[nomad-consul-separate-cluster](https://github.com/hashicorp/terraform-aws-nomad/tree/master/examples/nomad-consul-separate-cluster) example, the 
-[nomad-examples-helper.sh script](https://github.com/hashicorp/terraform-aws-nomad/tree/master/examples/nomad-examples-helper/nomad-examples-helper.sh) will do the tag lookup for 
-you automatically (note, you must have the [AWS CLI](https://aws.amazon.com/cli/), 
+[nomad-consul-separate-cluster](https://github.com/hashicorp/terraform-aws-nomad/tree/master/examples/nomad-consul-separate-cluster) example, the
+[nomad-examples-helper.sh script](https://github.com/hashicorp/terraform-aws-nomad/tree/master/examples/nomad-examples-helper/nomad-examples-helper.sh) will do the tag lookup for
+you automatically (note, you must have the [AWS CLI](https://aws.amazon.com/cli/),
 [jq](https://stedolan.github.io/jq/), and the [Nomad agent](https://www.nomadproject.io/) installed locally):
 
 ```
-> ../nomad-examples-helper/nomad-examples-helper.sh 
+> ../nomad-examples-helper/nomad-examples-helper.sh
 
 Your Nomad servers are running at the following IP addresses:
 
@@ -91,7 +91,7 @@ Your Nomad servers are running at the following IP addresses:
 54.236.16.38
 ```
 
-Copy and paste one of these IPs and use it with the `-address` argument for any [Nomad 
+Copy and paste one of these IPs and use it with the `-address` argument for any [Nomad
 command](https://www.nomadproject.io/docs/commands/index.html). For example, to see the status of all the Nomad
 servers:
 
@@ -118,7 +118,7 @@ ec2d4bd6  us-east-1c  i-01523bf946d98003e  <none>  false  ready
 ```
 
 And to submit a job called `example.nomad`:
- 
+
 ```
 > nomad run -address=http://<INSTANCE_IP_ADDR>:4646 example.nomad
 
@@ -133,9 +133,9 @@ And to submit a job called `example.nomad`:
 
 ### Using the Nomad agent on another EC2 Instance
 
-For production usage, your EC2 Instances should be running the [Nomad 
+For production usage, your EC2 Instances should be running the [Nomad
 agent](https://www.nomadproject.io/docs/agent/index.html). The agent nodes should discover the Nomad server nodes
-automatically using Consul. Check out the [Service Discovery 
+automatically using Consul. Check out the [Service Discovery
 documentation](https://www.nomadproject.io/docs/service-discovery/index.html) for details.
 
 
@@ -157,7 +157,7 @@ This architecture consists of the following resources:
 ### Auto Scaling Group
 
 This module runs Nomad on top of an [Auto Scaling Group (ASG)](https://aws.amazon.com/autoscaling/). Typically, you
-should run the ASG with 3 or 5 EC2 Instances spread across multiple [Availability 
+should run the ASG with 3 or 5 EC2 Instances spread across multiple [Availability
 Zones](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html). Each of the EC2
 Instances should be running an AMI that has had Nomad installed via the [install-nomad](https://github.com/hashicorp/terraform-aws-nomad/tree/master/modules/install-nomad)
 module. You pass in the ID of the AMI to run using the `ami_id` input parameter.
@@ -166,23 +166,23 @@ module. You pass in the ID of the AMI to run using the `ami_id` input parameter.
 ### Security Group
 
 Each EC2 Instance in the ASG has a Security Group that allows:
- 
+
 * All outbound requests
-* All the inbound ports specified in the [Nomad 
+* All the inbound ports specified in the [Nomad
   documentation](https://www.nomadproject.io/docs/agent/configuration/index.html#ports)
 
-The Security Group ID is exported as an output variable if you need to add additional rules. 
+The Security Group ID is exported as an output variable if you need to add additional rules.
 
-Check out the [Security section](#security) for more details. 
+Check out the [Security section](#security) for more details.
 
 
 ### IAM Role and Permissions
 
-Each EC2 Instance in the ASG has an [IAM Role](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html) attached. 
-We give this IAM role a small set of IAM permissions that each EC2 Instance can use to automatically discover the other 
-Instances in its ASG and form a cluster with them. 
+Each EC2 Instance in the ASG has an [IAM Role](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html) attached.
+We give this IAM role a small set of IAM permissions that each EC2 Instance can use to automatically discover the other
+Instances in its ASG and form a cluster with them.
 
-The IAM Role ARN is exported as an output variable if you need to add additional permissions. 
+The IAM Role ARN is exported as an output variable if you need to add additional permissions.
 
 
 
@@ -204,9 +204,9 @@ NOT actually deploy those new instances. To make that happen, you should do the 
     ```
     nomad server-force-leave -address=<OLD_INSTANCE_IP>:4646
     ```
-    
+
 1. Once the instance has left the cluster, terminate it:
- 
+
     ```
     aws ec2 terminate-instances --instance-ids <OLD_INSTANCE_ID>
     ```
@@ -216,7 +216,7 @@ NOT actually deploy those new instances. To make that happen, you should do the 
 1. Wait for the new Instance to boot and join the cluster.
 
 1. Repeat these steps for each of the other old Instances in the ASG.
-   
+
 We will add a script in the future to automate this process (PRs are welcome!).
 
 
@@ -226,14 +226,63 @@ We will add a script in the future to automate this process (PRs are welcome!).
 ## What happens if a node crashes?
 
 There are two ways a Nomad node may go down:
- 
+
 1. The Nomad process may crash. In that case, `supervisor` should restart it automatically.
-1. The EC2 Instance running Nomad dies. In that case, the Auto Scaling Group should launch a replacement automatically. 
+1. The EC2 Instance running Nomad dies. In that case, the Auto Scaling Group should launch a replacement automatically.
    Note that in this case, since the Nomad agent did not exit gracefully, and the replacement will have a different ID,
    you may have to manually clean out the old nodes using the [server-force-leave
-   command](https://www.nomadproject.io/docs/commands/server-force-leave.html). We may add a script to do this 
-   automatically in the future. For more info, see the [Nomad Outage 
+   command](https://www.nomadproject.io/docs/commands/server-force-leave.html). We may add a script to do this
+   automatically in the future. For more info, see the [Nomad Outage
    documentation](https://www.nomadproject.io/guides/outage.html).
+
+
+
+
+
+## How do you connect load balancers to the Auto Scaling Group (ASG)?
+
+You can use the [`aws_autoscaling_attachment`](https://www.terraform.io/docs/providers/aws/r/autoscaling_attachment.html) resource.
+
+For example, if you are using the new application or network load balancers:
+
+```hcl
+resource "aws_lb_target_group" "test" {
+  // ...
+}
+
+# Create a new Nomad Cluster
+module "nomad" {
+  source ="..."
+  // ...
+}
+
+# Create a new load balancer attachment
+resource "aws_autoscaling_attachment" "asg_attachment_bar" {
+  autoscaling_group_name = "${module.nomad.asg_name}"
+  alb_target_group_arn   = "${aws_alb_target_group.test.arn}"
+}
+```
+
+If you are using a "classic" load balancer:
+
+```hcl
+# Create a new load balancer
+resource "aws_elb" "bar" {
+  // ...
+}
+
+# Create a new Nomad Cluster
+module "nomad" {
+  source ="..."
+  // ...
+}
+
+# Create a new load balancer attachment
+resource "aws_autoscaling_attachment" "asg_attachment_bar" {
+  autoscaling_group_name = "${module.nomad.asg_name}"
+  elb                    = "${aws_elb.bar.id}"
+}
+```
 
 
 
@@ -260,30 +309,30 @@ Nomad can encrypt all of its network traffic. For instructions on enabling netwo
 
 The EC2 Instances in the cluster store all their data on the root EBS Volume. To enable encryption for the data at
 rest, you must enable encryption in your Nomad AMI. If you're creating the AMI using Packer (e.g. as shown in
-the [nomad-consul-ami example](https://github.com/hashicorp/terraform-aws-nomad/tree/master/examples/nomad-consul-ami)), you need to set the [encrypt_boot 
-parameter](https://www.packer.io/docs/builders/amazon-ebs.html#encrypt_boot) to `true`.  
+the [nomad-consul-ami example](https://github.com/hashicorp/terraform-aws-nomad/tree/master/examples/nomad-consul-ami)), you need to set the [encrypt_boot
+parameter](https://www.packer.io/docs/builders/amazon-ebs.html#encrypt_boot) to `true`.
 
 
 ### Dedicated instances
 
-If you wish to use dedicated instances, you can set the `tenancy` parameter to `"dedicated"` in this module. 
+If you wish to use dedicated instances, you can set the `tenancy` parameter to `"dedicated"` in this module.
 
 
 ### Security groups
 
 This module attaches a security group to each EC2 Instance that allows inbound requests as follows:
 
-* **Nomad**: For all the [ports used by Nomad](https://www.nomadproject.io/docs/agent/configuration/index.html#ports), 
-  you can use the `allowed_inbound_cidr_blocks` parameter to control the list of 
-  [CIDR blocks](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing) that will be allowed access.  
+* **Nomad**: For all the [ports used by Nomad](https://www.nomadproject.io/docs/agent/configuration/index.html#ports),
+  you can use the `allowed_inbound_cidr_blocks` parameter to control the list of
+  [CIDR blocks](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing) that will be allowed access.
 
-* **SSH**: For the SSH port (default: 22), you can use the `allowed_ssh_cidr_blocks` parameter to control the list of   
-  [CIDR blocks](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing) that will be allowed access. 
-  
+* **SSH**: For the SSH port (default: 22), you can use the `allowed_ssh_cidr_blocks` parameter to control the list of
+  [CIDR blocks](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing) that will be allowed access.
+
 Note that all the ports mentioned above are configurable via the `xxx_port` variables (e.g. `http_port`). See
-[vars.tf](vars.tf) for the full list.  
-  
-  
+[vars.tf](vars.tf) for the full list.
+
+
 
 ### SSH access
 
@@ -308,21 +357,21 @@ This module does NOT handle the following items, which you may want to provide o
 ### Consul
 
 This module assumes you already have Consul deployed in a separate cluster. If you want to run Nomad and Consul on the
-same cluster, instead of using this module, see the [Deploy Nomad and Consul in the same cluster 
+same cluster, instead of using this module, see the [Deploy Nomad and Consul in the same cluster
 documentation](https://github.com/hashicorp/terraform-aws-nomad/tree/master/README.md#deploy-nomad-and-consul-in-the-same-cluster).
 
 
 ### Monitoring, alerting, log aggregation
 
-This module does not include anything for monitoring, alerting, or log aggregation. All ASGs and EC2 Instances come 
-with limited [CloudWatch](https://aws.amazon.com/cloudwatch/) metrics built-in, but beyond that, you will have to 
+This module does not include anything for monitoring, alerting, or log aggregation. All ASGs and EC2 Instances come
+with limited [CloudWatch](https://aws.amazon.com/cloudwatch/) metrics built-in, but beyond that, you will have to
 provide your own solutions.
 
 
 ### VPCs, subnets, route tables
 
-This module assumes you've already created your network topology (VPC, subnets, route tables, etc). You will need to 
-pass in the the relevant info about your network topology (e.g. `vpc_id`, `subnet_ids`) as input variables to this 
+This module assumes you've already created your network topology (VPC, subnets, route tables, etc). You will need to
+pass in the the relevant info about your network topology (e.g. `vpc_id`, `subnet_ids`) as input variables to this
 module.
 
 

--- a/modules/nomad-cluster/main.tf
+++ b/modules/nomad-cluster/main.tf
@@ -21,8 +21,6 @@ resource "aws_autoscaling_group" "autoscaling_group" {
   desired_capacity     = "${var.desired_capacity}"
   termination_policies = ["${var.termination_policies}"]
 
-  target_group_arns         = ["${var.target_group_arns}"]
-  load_balancers            = ["${var.load_balancers}"]
   health_check_type         = "${var.health_check_type}"
   health_check_grace_period = "${var.health_check_grace_period}"
   wait_for_capacity_timeout = "${var.wait_for_capacity_timeout}"

--- a/modules/nomad-cluster/variables.tf
+++ b/modules/nomad-cluster/variables.tf
@@ -109,18 +109,6 @@ variable "root_volume_delete_on_termination" {
   default     = true
 }
 
-variable "target_group_arns" {
-  description = "A list of target group ARNs of Application Load Balanacer (ALB) targets to associate with this ASG. If you're using a Elastic Load Balancer (AKA ELB Classic), use the load_balancers variable instead."
-  type        = "list"
-  default     = []
-}
-
-variable "load_balancers" {
-  description = "A list of Elastic Load Balancer (ELB) names to associate with this ASG. If you're using an Application Load Balancer (ALB), use the target_group_arns variable instead."
-  type        = "list"
-  default     = []
-}
-
 variable "wait_for_capacity_timeout" {
   description = "A maximum duration that Terraform should wait for ASG instances to be healthy before timing out. Setting this to '0' causes Terraform to skip all Capacity Waiting behavior."
   default     = "10m"


### PR DESCRIPTION
Fixes #19

This is backwards incompatible and a breaking change.

## Migration Instruction

### `load_balancers`
For each existing load balancer specified with the `load_balancers` variable, define a new `aws_autoscaling_attachment` . For example:

```hcl
# Create a new load balancer
resource "aws_elb" "bar" {
  // ...
}

# Create a new Nomad Cluster
module "nomad" {
  source ="..."
  // ...
}

# Create a new load balancer attachment
resource "aws_autoscaling_attachment" "asg_attachment_bar" {
  autoscaling_group_name = "${module.nomad.asg_name}"
  elb                    = "${aws_elb.bar.id}"
}
```

### `target_group_arns`
For each existing target group specified with the `target_group_arns` variable, define a new `aws_autoscaling_attachment` . For example:

```hcl
resource "aws_lb_target_group" "test" {
  // ...
}

# Create a new Nomad Cluster
module "nomad" {
  source ="..."
  // ...
}

# Create a new load balancer attachment
resource "aws_autoscaling_attachment" "asg_attachment_bar" {
  autoscaling_group_name = "${module.nomad.asg_name}"
  alb_target_group_arn   = "${aws_alb_target_group.test.arn}"
}
```
