### PR TITLE
Fix Consul version. Fix Git URLs. Fix Nomad tags.

### DIFF
--- a/examples/nomad-consul-ami/nomad-consul-docker.json
+++ b/examples/nomad-consul-ami/nomad-consul-docker.json
@@ -3,7 +3,7 @@
   "variables": {
     "aws_region": "us-east-1",
     "nomad_version": "0.7.1",
-    "consul_module_version": "v0.1.0",
+    "consul_module_version": "v0.3.1",
     "consul_version": "1.0.3"
   },
   "builders": [

--- a/examples/nomad-consul-ami/nomad-consul.json
+++ b/examples/nomad-consul-ami/nomad-consul.json
@@ -3,7 +3,7 @@
   "variables": {
     "aws_region": "us-east-1",
     "nomad_version": "0.7.1",
-    "consul_module_version": "v0.1.0",
+    "consul_module_version": "v0.3.1",
     "consul_version": "1.0.3"
   },
   "builders": [

--- a/examples/nomad-consul-separate-cluster/main.tf
+++ b/examples/nomad-consul-separate-cluster/main.tf
@@ -77,10 +77,6 @@ module "nomad_servers" {
   max_size         = "${var.num_nomad_servers}"
   desired_capacity = "${var.num_nomad_servers}"
 
-  # The EC2 Instances will use these tags to automatically discover each other and form a cluster
-  cluster_tag_key   = "${var.cluster_tag_key}"
-  cluster_tag_value = "${var.consul_cluster_name}"
-
   ami_id    = "${var.ami_id == "" ? data.aws_ami.nomad_consul.image_id : var.ami_id}"
   user_data = "${data.template_file.user_data_nomad_server.rendered}"
 

--- a/main.tf
+++ b/main.tf
@@ -60,7 +60,7 @@ data "aws_ami" "nomad_consul" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 module "servers" {
-  source = "git::git@github.com:hashicorp/terraform-aws-consul.git//modules/consul-cluster?ref=v0.1.0"
+  source = "github.com/hashicorp/terraform-aws-consul//modules/consul-cluster?ref=v0.3.1"
 
   cluster_name  = "${var.cluster_name}-server"
   cluster_size  = "${var.num_servers}"
@@ -100,7 +100,7 @@ module "servers" {
 module "nomad_security_group_rules" {
   # When using these modules in your own templates, you will need to use a Git URL with a ref attribute that pins you
   # to a specific version of the modules, such as the following example:
-  # source = "git::git@github.com:hashicorp/terraform-aws-nomad.git//modules/nomad-security-group-rules?ref=v0.0.1"
+  # source = "github.com/hashicorp/terraform-aws-nomad//modules/nomad-security-group-rules?ref=v0.0.1"
   source = "./modules/nomad-security-group-rules"
 
   # To make testing easier, we allow requests from any IP address here but in a production deployment, we strongly
@@ -131,15 +131,15 @@ data "template_file" "user_data_server" {
 module "clients" {
   # When using these modules in your own templates, you will need to use a Git URL with a ref attribute that pins you
   # to a specific version of the modules, such as the following example:
-  # source = "git::git@github.com:hashicorp/terraform-aws-nomad.git//modules/nomad-cluster?ref=v0.0.1"
+  # source = "github.com/hashicorp/terraform-aws-nomad//modules/nomad-cluster?ref=v0.0.1"
   source = "./modules/nomad-cluster"
 
   cluster_name  = "${var.cluster_name}-client"
   instance_type = "${var.instance_type}"
 
-  # The EC2 Instances will use these tags to automatically discover the servers
-  cluster_tag_key   = "${var.cluster_tag_key}"
-  cluster_tag_value = "${var.cluster_tag_value}"
+  # Give the clients a different tag so they don't try to join the server cluster
+  cluster_tag_key   = "nomad-clients"
+  cluster_tag_value = "${var.cluster_name}"
 
   # To keep the example simple, we are using a fixed-size cluster. In real-world usage, you could use auto scaling
   # policies to dynamically resize the cluster in response to load.
@@ -175,7 +175,7 @@ module "clients" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 module "consul_iam_policies" {
-  source = "git::git@github.com:hashicorp/terraform-aws-consul.git//modules/consul-iam-policies?ref=v0.1.0"
+  source = "github.com/hashicorp/terraform-aws-consul//modules/consul-iam-policies?ref=v0.3.1"
 
   iam_role_id = "${module.clients.iam_role_id}"
 }

--- a/modules/nomad-cluster/outputs.tf
+++ b/modules/nomad-cluster/outputs.tf
@@ -7,7 +7,7 @@ output "cluster_tag_key" {
 }
 
 output "cluster_tag_value" {
-  value = "${var.cluster_name}"
+  value = "${var.cluster_tag_value}"
 }
 
 output "cluster_size" {

--- a/modules/nomad-security-group-rules/README.md
+++ b/modules/nomad-security-group-rules/README.md
@@ -11,7 +11,7 @@ servers that have both Nomad and Consul on each node:
 
 ```hcl
 module "consul_servers" {
-  source = "git::git@github.com:hashicorp/terraform-aws-consul.git//modules/consul-cluster?ref=v0.0.1"
+  source = "github.com/hashicorp/terraform-aws-consul//modules/consul-cluster?ref=v0.3.1"
   
   # This AMI has both Nomad and Consul installed
   ami_id = "ami-1234abcd"
@@ -24,7 +24,7 @@ servers have the necessary ports open for using Nomad, you can use this module a
 
 ```hcl
 module "security_group_rules" {
-  source = "git::git@github.com:hashicorp/terraform-aws-nomad.git//modules/nomad-security-group-rules?ref=v0.0.1"
+  source = "github.com/hashicorp/terraform-aws-nomad//modules/nomad-security-group-rules?ref=v0.0.1"
 
   security_group_id = "${module.consul_servers.security_group_id}"
   

--- a/test/glide.yaml
+++ b/test/glide.yaml
@@ -1,4 +1,4 @@
-package: github.com/hashicorp/terraform-aws-consul/test
+package: github.com/hashicorp/terraform-aws-nomad/test
 owners:
 - name: Gruntwork
   homepage: http://www.gruntwork.io


### PR DESCRIPTION
Fix a bunch of minor bugs that have crept up due to CI issues with running tests:

1. Update Consul usage to v0.3.1 everywhere, so the `tags` param is exposed. This fixes #26.

1. Update all Git URLs to use HTTPS instead of SSH for consistency.

1. Fix tags set on Nomad cluster in root example. Nomad clients should not get the same tags as servers.