### PR TITLE
Remove provider and aws_region from examples

### DIFF
--- a/examples/nomad-consul-separate-cluster/README.md
+++ b/examples/nomad-consul-separate-cluster/README.md
@@ -23,14 +23,16 @@ For more info on how the Nomad cluster works, check out the [nomad-cluster](http
 To deploy a Nomad Cluster:
 
 1. `git clone` this repo to your computer.
-1. Build a Nomad and Consul AMI. See the [nomad-consul-ami example](https://github.com/hashicorp/terraform-aws-nomad/tree/master/examples/nomad-consul-ami) documentation for 
+1. Optional: build a Nomad and Consul AMI. See the [nomad-consul-ami
+   example](https://github.com/hashicorp/terraform-aws-nomad/tree/master/examples/nomad-consul-ami) documentation for
    instructions. Make sure to note down the ID of the AMI.
 1. Install [Terraform](https://www.terraform.io/).
 1. Open `vars.tf`, set the environment variables specified at the top of the file, and fill in any other variables that
-   don't have a default, including putting your AMI ID into the `ami_id` variable.
-1. Run `terraform get`.
-1. Run `terraform plan`.
-1. If the plan looks good, run `terraform apply`.
-1. Run the [nomad-examples-helper.sh script](https://github.com/hashicorp/terraform-aws-nomad/tree/master/examples/nomad-examples-helper/nomad-examples-helper.sh) to print out 
+   don't have a default. If you built a custom AMI, put the AMI ID into the `ami_id` variable. Otherwise, one of our
+   public example AMIs will be used by default. These AMIs are great for learning/experimenting, but are NOT
+   recommended for production use.
+1. Run `terraform init`.
+1. Run `terraform apply`.
+1. Run the [nomad-examples-helper.sh script](https://github.com/hashicorp/terraform-aws-nomad/tree/master/examples/nomad-examples-helper/nomad-examples-helper.sh) to print out
    the IP addresses of the Nomad servers and some example commands you can run to interact with the cluster:
    `../nomad-examples-helper/nomad-examples-helper.sh`.

--- a/examples/nomad-consul-separate-cluster/main.tf
+++ b/examples/nomad-consul-separate-cluster/main.tf
@@ -12,11 +12,6 @@
 # Packer template in the Consul AWS Module.
 # ---------------------------------------------------------------------------------------------------------------------
 
-provider "aws" {
-  profile = "${var.aws_profile}"
-  region  = "${var.aws_region}"
-}
-
 # Terraform 0.9.5 suffered from https://github.com/hashicorp/terraform/issues/14399, which causes this template the
 # conditionals in this template to fail.
 terraform {
@@ -239,3 +234,5 @@ data "aws_vpc" "default" {
 data "aws_subnet_ids" "default" {
   vpc_id = "${data.aws_vpc.default.id}"
 }
+
+data "aws_region" "current" {}

--- a/examples/nomad-consul-separate-cluster/outputs.tf
+++ b/examples/nomad-consul-separate-cluster/outputs.tf
@@ -71,7 +71,7 @@ output "security_group_id_nomad_clients" {
 }
 
 output "aws_region" {
-  value = "${var.aws_region}"
+  value = "${data.aws_region.current.name}"
 }
 
 output "nomad_servers_cluster_tag_key" {

--- a/examples/nomad-consul-separate-cluster/variables.tf
+++ b/examples/nomad-consul-separate-cluster/variables.tf
@@ -5,12 +5,7 @@
 
 # AWS_ACCESS_KEY_ID
 # AWS_SECRET_ACCESS_KEY
-# or
-# AWS_PROFILE
-# or
-# Beside this it is as well possible to make use of the provided variable "aws_profile".
-# Either specifiy it in your tfvars configuration or as configuration parameter:
-#  "terraform plan -var 'aws_profile=<local_profile_name>'"
+# AWS_DEFAULT_REGION
 
 # ---------------------------------------------------------------------------------------------------------------------
 # REQUIRED PARAMETERS
@@ -27,16 +22,6 @@
 variable "ami_id" {
   description = "The ID of the AMI to run in the cluster. This should be an AMI built from the Packer template under examples/nomad-consul-ami/nomad-consul.json. If no AMI is specified, the template will 'just work' by using the example public AMIs. WARNING! Do not use the example AMIs in a production setting!"
   default = ""
-}
-
-variable "aws_profile" {
-  description = "Specify the local AWS profile configuration to use."
-  default     = "default"
-}
-
-variable "aws_region" {
-  description = "The AWS region to deploy into (e.g. us-east-1)."
-  default     = "us-east-1"
 }
 
 variable "nomad_cluster_name" {

--- a/examples/root-example/README.md
+++ b/examples/root-example/README.md
@@ -23,15 +23,17 @@ For more info on how the Nomad cluster works, check out the [nomad-cluster](http
 To deploy a Nomad Cluster:
 
 1. `git clone` this repo to your computer.
-1. Build a Nomad and Consul AMI. See the [nomad-consul-ami example](https://github.com/hashicorp/terraform-aws-nomad/tree/master/examples/nomad-consul-ami) documentation for 
+1. Optional: build a Nomad and Consul AMI. See the [nomad-consul-ami
+   example](https://github.com/hashicorp/terraform-aws-nomad/tree/master/examples/nomad-consul-ami) documentation for
    instructions. Make sure to note down the ID of the AMI.
 1. Install [Terraform](https://www.terraform.io/).
 1. Open `vars.tf`, set the environment variables specified at the top of the file, and fill in any other variables that
-   don't have a default, including putting your AMI ID into the `ami_id` variable.
-1. Run `terraform get`.
-1. Run `terraform plan`.
-1. If the plan looks good, run `terraform apply`.
-1. Run the [nomad-examples-helper.sh script](https://github.com/hashicorp/terraform-aws-nomad/tree/master/examples/nomad-examples-helper/nomad-examples-helper.sh) to print out 
+   don't have a default. If you built a custom AMI, put the AMI ID into the `ami_id` variable. Otherwise, one of our
+   public example AMIs will be used by default. These AMIs are great for learning/experimenting, but are NOT
+   recommended for production use.
+1. Run `terraform init`.
+1. Run `terraform apply`.
+1. Run the [nomad-examples-helper.sh script](https://github.com/hashicorp/terraform-aws-nomad/tree/master/examples/nomad-examples-helper/nomad-examples-helper.sh) to print out
    the IP addresses of the Nomad servers and some example commands you can run to interact with the cluster:
    `../nomad-examples-helper/nomad-examples-helper.sh`.
    

--- a/main.tf
+++ b/main.tf
@@ -8,10 +8,6 @@
 # ami_id input variable is built from the examples/nomad-consul-ami/nomad-consul.json Packer template.
 # ---------------------------------------------------------------------------------------------------------------------
 
-provider "aws" {
-  region = "${var.aws_region}"
-}
-
 # Terraform 0.9.5 suffered from https://github.com/hashicorp/terraform/issues/14399, which causes this template the
 # conditionals in this template to fail.
 terraform {
@@ -208,3 +204,5 @@ data "aws_vpc" "default" {
 data "aws_subnet_ids" "default" {
   vpc_id = "${data.aws_vpc.default.id}"
 }
+
+data "aws_region" "current" {}

--- a/outputs.tf
+++ b/outputs.tf
@@ -47,7 +47,7 @@ output "security_group_id_clients" {
 }
 
 output "aws_region" {
-  value = "${var.aws_region}"
+  value = "${data.aws_region.current.name}"
 }
 
 output "nomad_servers_cluster_tag_key" {

--- a/test/Gopkg.lock
+++ b/test/Gopkg.lock
@@ -28,8 +28,8 @@
 [[projects]]
   name = "github.com/gruntwork-io/terratest"
   packages = ["modules/aws","modules/collections","modules/files","modules/logger","modules/packer","modules/random","modules/retry","modules/shell","modules/ssh","modules/terraform","modules/test-structure"]
-  revision = "b9eaa580d17795b28ac89173b066d951c6feb3c4"
-  version = "v0.9.1"
+  revision = "baaee143a328ab0fe3a78a0ebc80bb0f707ef8fc"
+  version = "v0.9.2"
 
 [[projects]]
   name = "github.com/jmespath/go-jmespath"

--- a/test/Gopkg.toml
+++ b/test/Gopkg.toml
@@ -23,4 +23,4 @@
 
 [[constraint]]
   name = "github.com/gruntwork-io/terratest"
-  version = "0.9.1"
+  version = "0.9.2"

--- a/test/nomad_helpers.go
+++ b/test/nomad_helpers.go
@@ -17,7 +17,8 @@ import (
 
 const REPO_ROOT = "../"
 
-const VAR_AWS_REGION = "aws_region"
+const ENV_VAR_AWS_REGION = "AWS_DEFAULT_REGION"
+
 const VAR_AMI_ID = "ami_id"
 
 const CLUSTER_COLOCATED_EXAMPLE_PATH = "/"
@@ -76,11 +77,13 @@ func runNomadClusterColocatedTest(t *testing.T, packerBuildName string) {
 		terraformOptions := &terraform.Options{
 			TerraformDir: examplesDir,
 			Vars: map[string]interface{}{
-				VAR_AWS_REGION:                             awsRegion,
 				CLUSTER_COLOCATED_EXAMPLE_VAR_CLUSTER_NAME: fmt.Sprintf("test-%s", uniqueId),
 				CLUSTER_COLOCATED_EXAMPLE_VAR_NUM_SERVERS:  DEFAULT_NUM_SERVERS,
 				CLUSTER_COLOCATED_EXAMPLE_VAR_NUM_CLIENTS:  DEFAULT_NUM_CLIENTS,
 				VAR_AMI_ID:                                 amiId,
+			},
+			EnvVars: map[string]string{
+				ENV_VAR_AWS_REGION: awsRegion,
 			},
 		}
 
@@ -132,13 +135,15 @@ func runNomadClusterSeparateTest(t *testing.T, packerBuildName string) {
 		terraformOptions := &terraform.Options{
 			TerraformDir: examplesDir,
 			Vars: map[string]interface{}{
-				VAR_AWS_REGION:                                   awsRegion,
 				CLUSTER_SEPARATE_EXAMPLE_VAR_NOMAD_CLUSTER_NAME:  fmt.Sprintf("test-%s", uniqueId),
 				CLUSTER_SEPARATE_EXAMPLE_VAR_CONSUL_CLUSTER_NAME: fmt.Sprintf("test-%s", uniqueId),
 				CLUSTER_SEPARATE_EXAMPLE_VAR_NUM_NOMAD_SERVERS:   DEFAULT_NUM_SERVERS,
 				CLUSTER_SEPARATE_EXAMPLE_VAR_NUM_CONSUL_SERVERS:  DEFAULT_NUM_SERVERS,
 				CLUSTER_SEPARATE_EXAMPLE_VAR_NUM_NOMAD_CLIENTS:   DEFAULT_NUM_CLIENTS,
 				VAR_AMI_ID:                                       amiId,
+			},
+			EnvVars: map[string]string{
+				ENV_VAR_AWS_REGION: awsRegion,
 			},
 		}
 		terraform.InitAndApply(t, terraformOptions)

--- a/test/nomad_helpers.go
+++ b/test/nomad_helpers.go
@@ -63,10 +63,10 @@ func runNomadClusterColocatedTest(t *testing.T, packerBuildName string) {
 
 	test_structure.RunTestStage(t, "setup_ami", func() {
 		awsRegion := aws.GetRandomRegion(t, nil, nil)
-		amiId := buildAmi(t, AMI_EXAMPLE_PATH, packerBuildName, awsRegion)
-
-		test_structure.SaveAmiId(t, examplesDir, amiId)
 		test_structure.SaveString(t, examplesDir, SAVED_AWS_REGION, awsRegion)
+
+		amiId := buildAmi(t, AMI_EXAMPLE_PATH, packerBuildName, awsRegion)
+		test_structure.SaveAmiId(t, examplesDir, amiId)
 	})
 
 	test_structure.RunTestStage(t, "deploy", func() {
@@ -86,10 +86,9 @@ func runNomadClusterColocatedTest(t *testing.T, packerBuildName string) {
 				ENV_VAR_AWS_REGION: awsRegion,
 			},
 		}
+		test_structure.SaveTerraformOptions(t, examplesDir, terraformOptions)
 
 		terraform.InitAndApply(t, terraformOptions)
-
-		test_structure.SaveTerraformOptions(t, examplesDir, terraformOptions)
 	})
 
 	test_structure.RunTestStage(t, "validate", func() {
@@ -121,10 +120,10 @@ func runNomadClusterSeparateTest(t *testing.T, packerBuildName string) {
 
 	test_structure.RunTestStage(t, "setup_ami", func() {
 		awsRegion := aws.GetRandomRegion(t, nil, nil)
-		amiId := buildAmi(t, AMI_EXAMPLE_PATH, packerBuildName, awsRegion)
-
-		test_structure.SaveAmiId(t, examplesDir, amiId)
 		test_structure.SaveString(t, examplesDir, SAVED_AWS_REGION, awsRegion)
+
+		amiId := buildAmi(t, AMI_EXAMPLE_PATH, packerBuildName, awsRegion)
+		test_structure.SaveAmiId(t, examplesDir, amiId)
 	})
 
 	test_structure.RunTestStage(t, "deploy", func() {
@@ -146,9 +145,9 @@ func runNomadClusterSeparateTest(t *testing.T, packerBuildName string) {
 				ENV_VAR_AWS_REGION: awsRegion,
 			},
 		}
-		terraform.InitAndApply(t, terraformOptions)
-
 		test_structure.SaveTerraformOptions(t, examplesDir, terraformOptions)
+
+		terraform.InitAndApply(t, terraformOptions)
 	})
 
 	test_structure.RunTestStage(t, "validate", func() {

--- a/variables.tf
+++ b/variables.tf
@@ -5,6 +5,7 @@
 
 # AWS_ACCESS_KEY_ID
 # AWS_SECRET_ACCESS_KEY
+# AWS_DEFAULT_REGION
 
 # ---------------------------------------------------------------------------------------------------------------------
 # REQUIRED PARAMETERS
@@ -21,11 +22,6 @@
 variable "ami_id" {
   description = "The ID of the AMI to run in the cluster. This should be an AMI built from the Packer template under examples/nomad-consul-ami/nomad-consul.json. If no AMI is specified, the template will 'just work' by using the example public AMIs. WARNING! Do not use the example AMIs in a production setting!"
   default = ""
-}
-
-variable "aws_region" {
-  description = "The AWS region to deploy into (e.g. us-east-1)."
-  default     = "us-east-1"
 }
 
 variable "cluster_name" {


### PR DESCRIPTION
I’m removing the `provider` block and `aws_region` variable from the examples in this repo so that they work properly with the instructions you get from the auto-generated docs on the [Terraform Registry page](https://registry.terraform.io/modules/hashicorp/nomad/aws/0.4.0) for this module.