### PR TITLE
Make vpc_id an input parameter as well.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -198,7 +198,8 @@ data "template_file" "user_data_client" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 data "aws_vpc" "default" {
-  default = true
+  default = "${var.vpc_id == "" ? true : false}"
+  id      = "${var.vpc_id}"
 }
 
 data "aws_subnet_ids" "default" {

--- a/variables.tf
+++ b/variables.tf
@@ -58,3 +58,8 @@ variable "ssh_key_name" {
   description = "The name of an EC2 Key Pair that can be used to SSH to the EC2 Instances in this cluster. Set to an empty string to not associate a Key Pair."
   default     = ""
 }
+
+variable "vpc_id" {
+  description = "The ID of the VPC in which the nodes will be deployed.  Uses default VPC if not supplied."
+  default     = ""
+}


### PR DESCRIPTION
I noticed other modules such as consul/aws have a `vpc_id` input parameter and I needed this for my own use, does it make sense to to add this to this module?