### PR TITLE
Add possibility to add ebs_volumes for nomad nodes

### DIFF
--- a/examples/nomad-consul-separate-cluster/main.tf
+++ b/examples/nomad-consul-separate-cluster/main.tf
@@ -179,15 +179,19 @@ module "nomad_clients" {
   min_size         = "${var.num_nomad_clients}"
   max_size         = "${var.num_nomad_clients}"
   desired_capacity = "${var.num_nomad_clients}"
-  ami_id    = "${var.ami_id == "" ? data.aws_ami.nomad_consul.image_id : var.ami_id}"
-  user_data = "${data.template_file.user_data_nomad_client.rendered}"
-  vpc_id     = "${data.aws_vpc.default.id}"
-  subnet_ids = "${data.aws_subnet_ids.default.ids}"
+  ami_id           = "${var.ami_id == "" ? data.aws_ami.nomad_consul.image_id : var.ami_id}"
+  user_data        = "${data.template_file.user_data_nomad_client.rendered}"
+  vpc_id           = "${data.aws_vpc.default.id}"
+  subnet_ids       = "${data.aws_subnet_ids.default.ids}"
   # To make testing easier, we allow Consul and SSH requests from any IP address here but in a production
   # deployment, we strongly recommend you limit this to the IP address ranges of known, trusted servers inside your VPC.
   allowed_ssh_cidr_blocks = ["0.0.0.0/0"]
   allowed_inbound_cidr_blocks = ["0.0.0.0/0"]
   ssh_key_name                = "${var.ssh_key_name}"
+  ebs_block_devices = [{
+    "device_name" = "/dev/xvde"
+    "volume_size" = "10"
+  }]
 }
 
 # ---------------------------------------------------------------------------------------------------------------------

--- a/examples/nomad-consul-separate-cluster/main.tf
+++ b/examples/nomad-consul-separate-cluster/main.tf
@@ -179,17 +179,13 @@ module "nomad_clients" {
   min_size         = "${var.num_nomad_clients}"
   max_size         = "${var.num_nomad_clients}"
   desired_capacity = "${var.num_nomad_clients}"
-
   ami_id    = "${var.ami_id == "" ? data.aws_ami.nomad_consul.image_id : var.ami_id}"
   user_data = "${data.template_file.user_data_nomad_client.rendered}"
-
   vpc_id     = "${data.aws_vpc.default.id}"
   subnet_ids = "${data.aws_subnet_ids.default.ids}"
-
   # To make testing easier, we allow Consul and SSH requests from any IP address here but in a production
   # deployment, we strongly recommend you limit this to the IP address ranges of known, trusted servers inside your VPC.
   allowed_ssh_cidr_blocks = ["0.0.0.0/0"]
-
   allowed_inbound_cidr_blocks = ["0.0.0.0/0"]
   ssh_key_name                = "${var.ssh_key_name}"
 }

--- a/modules/nomad-cluster/main.tf
+++ b/modules/nomad-cluster/main.tf
@@ -65,6 +65,8 @@ resource "aws_launch_configuration" "launch_configuration" {
     delete_on_termination = "${var.root_volume_delete_on_termination}"
   }
 
+  ebs_block_device = ["${var.ebs_block_devices}"]
+
   # Important note: whenever using a launch configuration with an auto scaling group, you must set
   # create_before_destroy = true. However, as soon as you set create_before_destroy = true in one resource, you must
   # also set it in every resource that it depends on, or you'll get an error about cyclic dependencies (especially when

--- a/modules/nomad-cluster/main.tf
+++ b/modules/nomad-cluster/main.tf
@@ -13,7 +13,7 @@ terraform {
 resource "aws_autoscaling_group" "autoscaling_group" {
   launch_configuration = "${aws_launch_configuration.launch_configuration.name}"
 
-  name = "${var.asg_name}"
+  name                = "${var.asg_name}"
   availability_zones  = ["${var.availability_zones}"]
   vpc_zone_identifier = ["${var.subnet_ids}"]
 
@@ -95,7 +95,6 @@ resource "aws_security_group" "lc_security_group" {
     create_before_destroy = true
   }
 }
-
 
 resource "aws_security_group_rule" "allow_ssh_inbound" {
   type        = "ingress"

--- a/modules/nomad-cluster/variables.tf
+++ b/modules/nomad-cluster/variables.tf
@@ -182,6 +182,5 @@ variable "tags" {
 variable "ebs_block_devices" {
   description = "List of ebs volume definitions for those ebs_volumes that should be added to the instances created with the EC2 launch-configuration. Each element in the list is a map containing keys defined for ebs_block_device (see: https://www.terraform.io/docs/providers/aws/r/launch_configuration.html#ebs_block_device."
   type        = "list"
-
-  default = []
+  default     = []
 }

--- a/modules/nomad-cluster/variables.tf
+++ b/modules/nomad-cluster/variables.tf
@@ -170,3 +170,19 @@ variable "tags" {
   type        = "list"
   default     = []
 }
+
+# Example for a ebs_block_device created from a snapshot and one with a certain size.
+# ebs_block_devices = [{
+#    "device_name" = "/dev/xvdf"
+#    "snapshot_id" = "snap-XYZ"
+#  },
+#  {
+#    "device_name" = "/dev/xvde"
+#    "volume_size" = "50"
+#  }]
+variable "ebs_block_devices" {
+  description = "List of ebs volume definitions for those ebs_volumes that should be added to the instances created with the EC2 launch-configurationd. Each element in the list is a map containing keys defined for ebs_block_device (see: https://www.terraform.io/docs/providers/aws/r/launch_configuration.html#ebs_block_device."
+  type        = "list"
+
+  default = []
+}

--- a/modules/nomad-cluster/variables.tf
+++ b/modules/nomad-cluster/variables.tf
@@ -40,7 +40,6 @@ variable "desired_capacity" {
   description = "The desired number of nodes to have in the cluster. If you're using this to run Nomad servers, we strongly recommend setting this to 3 or 5."
 }
 
-
 # ---------------------------------------------------------------------------------------------------------------------
 # OPTIONAL PARAMETERS
 # These parameters have reasonable defaults.
@@ -141,17 +140,17 @@ variable "instance_profile_path" {
 
 variable "http_port" {
   description = "The port to use for HTTP"
-  default = 4646
+  default     = 4646
 }
 
 variable "rpc_port" {
   description = "The port to use for RPC"
-  default = 4647
+  default     = 4647
 }
 
 variable "serf_port" {
   description = "The port to use for Serf"
-  default = 4648
+  default     = 4648
 }
 
 variable "ssh_port" {
@@ -161,8 +160,8 @@ variable "ssh_port" {
 
 variable "security_groups" {
   description = "Additional security groups to attach to the EC2 instances"
-  type = "list"
-  default = []
+  type        = "list"
+  default     = []
 }
 
 variable "tags" {

--- a/modules/nomad-cluster/variables.tf
+++ b/modules/nomad-cluster/variables.tf
@@ -180,7 +180,7 @@ variable "tags" {
 #    "volume_size" = "50"
 #  }]
 variable "ebs_block_devices" {
-  description = "List of ebs volume definitions for those ebs_volumes that should be added to the instances created with the EC2 launch-configurationd. Each element in the list is a map containing keys defined for ebs_block_device (see: https://www.terraform.io/docs/providers/aws/r/launch_configuration.html#ebs_block_device."
+  description = "List of ebs volume definitions for those ebs_volumes that should be added to the instances created with the EC2 launch-configuration. Each element in the list is a map containing keys defined for ebs_block_device (see: https://www.terraform.io/docs/providers/aws/r/launch_configuration.html#ebs_block_device."
   type        = "list"
 
   default = []


### PR DESCRIPTION
The current solution does not support to attach ebs_volumes to the nomad nodes.

NEW: With this change it is possible to inject ebs_block_device configuration into the launch configuration for the nomad nodes.

TEST: Tested with running/ self-contained examples setting up a nomad-cluster w. multiple dc's (see: https://github.com/MatthiasScholz/cos/tree/master/examples/root-example and https://github.com/MatthiasScholz/cos/tree/master/examples/nomad-datacenter)