### PR TITLE
Terraform 0.12.x Upgrade

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,8 @@
 defaults: &defaults
-  # docker:
-  #   - image: 087285199408.dkr.ecr.us-east-1.amazonaws.com/circle-ci-test-image-base:latest
-  machine:
-    image: circleci/classic:201711-01    
+  docker:
+    - image: 087285199408.dkr.ecr.us-east-1.amazonaws.com/circle-ci-test-image-base:latest
+  #machine:
+  #  image: circleci/classic:201711-01    
   environment:
     GRUNTWORK_INSTALLER_VERSION: v0.0.21
     TERRATEST_LOG_PARSER_VERSION: v0.17.4
@@ -16,9 +16,9 @@ install_gruntwork_utils: &install_gruntwork_utils
   name: install gruntwork utils
   command: |
     curl -Ls https://raw.githubusercontent.com/gruntwork-io/gruntwork-installer/master/bootstrap-gruntwork-installer.sh | bash /dev/stdin --version "${GRUNTWORK_INSTALLER_VERSION}"
-    gruntwork-install --module-name "gruntwork-module-circleci-helpers" --repo "https://github.com/gruntwork-io/module-ci" --tag "${MODULE_CI_VERSION}"
-    gruntwork-install --binary-name "docs-generator" --repo "https://github.com/gruntwork-io/module-ci" --tag "v0.13.11"
-    gruntwork-install --binary-name "terratest_log_parser" --repo "https://github.com/gruntwork-io/terratest" --tag "${TERRATEST_LOG_PARSER_VERSION}"
+    sudo -E gruntwork-install --module-name "gruntwork-module-circleci-helpers" --repo "https://github.com/gruntwork-io/module-ci" --tag "${MODULE_CI_VERSION}"
+    sudo -E gruntwork-install --binary-name "docs-generator" --repo "https://github.com/gruntwork-io/module-ci" --tag "v0.13.11"
+    sudo -E gruntwork-install --binary-name "terratest_log_parser" --repo "https://github.com/gruntwork-io/terratest" --tag "${TERRATEST_LOG_PARSER_VERSION}"
     configure-environment-for-gruntwork-module \
       --circle-ci-2-machine-executor \
       --terraform-version ${TERRAFORM_VERSION} \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,6 @@
+workspace_root: &workspace_root /go/src/github.com/hashicorp/terraform-aws-nomad
 defaults: &defaults
+  working_directory: *workspace_root
   docker:
     - image: 087285199408.dkr.ecr.us-east-1.amazonaws.com/circle-ci-test-image-base:latest
   #machine:
@@ -15,6 +17,7 @@ defaults: &defaults
 install_gruntwork_utils: &install_gruntwork_utils
   name: install gruntwork utils
   command: |
+    echo 'export PATH=$HOME/terraform:$HOME/packer:$PATH' >> $BASH_ENV
     curl -Ls https://raw.githubusercontent.com/gruntwork-io/gruntwork-installer/master/bootstrap-gruntwork-installer.sh | bash /dev/stdin --version "${GRUNTWORK_INSTALLER_VERSION}"
     sudo -E gruntwork-install --module-name "gruntwork-module-circleci-helpers" --repo "https://github.com/gruntwork-io/module-ci" --tag "${MODULE_CI_VERSION}"
     sudo -E gruntwork-install --binary-name "docs-generator" --repo "https://github.com/gruntwork-io/module-ci" --tag "v0.13.11"
@@ -49,6 +52,7 @@ jobs:
             - dep-v2-{{ checksum "test/Gopkg.lock" }}
 
       - run:
+          <<: *defaults
           <<: *install_gruntwork_utils
 
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ install_gruntwork_utils: &install_gruntwork_utils
     curl -Ls https://raw.githubusercontent.com/gruntwork-io/gruntwork-installer/master/bootstrap-gruntwork-installer.sh | bash /dev/stdin --version "${GRUNTWORK_INSTALLER_VERSION}"
     sudo -E gruntwork-install --module-name "gruntwork-module-circleci-helpers" --repo "https://github.com/gruntwork-io/module-ci" --tag "${MODULE_CI_VERSION}"
     sudo -E gruntwork-install --binary-name "docs-generator" --repo "https://github.com/gruntwork-io/module-ci" --tag "v0.13.11"
-    sudo -E gruntwork-install --binary-name "terratest_log_parser" --repo "https://github.com/gruntwork-io/terratest" --tag "${TERRATEST_LOG_PARSER_VERSION}"
+    # sudo -E gruntwork-install --binary-name "terratest_log_parser" --repo "https://github.com/gruntwork-io/terratest" --tag "${TERRATEST_LOG_PARSER_VERSION}"
     configure-environment-for-gruntwork-module \
       --terraform-version ${TERRAFORM_VERSION} \
       --terragrunt-version ${TERRAGRUNT_VERSION} \
@@ -74,10 +74,10 @@ jobs:
           command: run-go-tests --circle-ci-2 --path test --timeout 2h | tee /tmp/logs/all.log
           no_output_timeout: 3600s
 
-      - run:
-          name: parse test output
-          command: terratest_log_parser --testlog /tmp/logs/all.log --outputdir /tmp/logs
-          when: always
+      # - run:
+      #     name: parse test output
+      #     command: terratest_log_parser --testlog /tmp/logs/all.log --outputdir /tmp/logs
+      #     when: always
 
       - store_artifacts:
           path: /tmp/logs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,30 @@
----
-workspace_root: &workspace_root
-  /go/src/github.com/hashicorp/terraform-aws-nomad
-
 defaults: &defaults
-  working_directory: *workspace_root
   docker:
     - image: 087285199408.dkr.ecr.us-east-1.amazonaws.com/circle-ci-test-image-base:latest
+  environment:
+    GRUNTWORK_INSTALLER_VERSION: v0.0.21
+    TERRATEST_LOG_PARSER_VERSION: v0.17.4
+    MODULE_CI_VERSION: v0.13.15
+    TERRAFORM_VERSION: 0.12.2
+    TERRAGRUNT_VERSION: NONE
+    PACKER_VERSION: 1.4.1
+    GOLANG_VERSION: 1.11
+
+install_gruntwork_utils: &install_gruntwork_utils
+  name: install gruntwork utils
+  command: |
+    curl -Ls https://raw.githubusercontent.com/gruntwork-io/gruntwork-installer/master/bootstrap-gruntwork-installer.sh | bash /dev/stdin --version "${GRUNTWORK_INSTALLER_VERSION}"
+    gruntwork-install --module-name "gruntwork-module-circleci-helpers" --repo "https://github.com/gruntwork-io/module-ci" --tag "${MODULE_CI_VERSION}"
+    gruntwork-install --binary-name "docs-generator" --repo "https://github.com/gruntwork-io/module-ci" --tag "v0.13.11"
+    gruntwork-install --binary-name "terratest_log_parser" --repo "https://github.com/gruntwork-io/terratest" --tag "${TERRATEST_LOG_PARSER_VERSION}"
+    configure-environment-for-gruntwork-module \
+      --circle-ci-2-machine-executor \
+      --terraform-version ${TERRAFORM_VERSION} \
+      --terragrunt-version ${TERRAGRUNT_VERSION} \
+      --packer-version ${PACKER_VERSION} \
+      --use-go-dep \
+      --go-version ${GOLANG_VERSION} \
+      --go-src-path test    
 
 version: 2
 jobs:
@@ -18,32 +37,33 @@ jobs:
           name: Validate Terraform Formatting
           command: "[ -z \"$(terraform fmt -write=false)\" ] || { terraform fmt -write=false -diff; exit 1; }"
 
-  build:
-    <<: *defaults
-    steps:
-      - checkout
-      - attach_workspace:
-          at: *workspace_root
-      - restore_cache:
-          keys:
-            - dep-{{ checksum "test/Gopkg.lock" }}
-      - run: configure-environment-for-gruntwork-module --go-src-path test --use-go-dep --circle-ci-2
-      - save_cache:
-          key: dep-{{ checksum "test/Gopkg.lock" }}
-          paths:
-            - /go/src/github.com/hashicorp/terraform-aws-nomad/test/vendor
-      - persist_to_workspace:
-          root: *workspace_root
-          paths: test/vendor
-
   test:
     <<: *defaults
     steps:
       - checkout
+      - run:
+          <<: *install_gruntwork_utils
+                
       - run: echo 'export PATH=$HOME/terraform:$HOME/packer:$PATH' >> $BASH_ENV
-      - attach_workspace:
-          at: *workspace_root
-      - run: run-go-tests --circle-ci-2 --path test
+
+      - run:
+          name: create log directory
+          command: mkdir -p /tmp/logs
+
+      - run:
+          name: run tests
+          command: run-go-tests --path test --timeout 2h | tee /tmp/logs/all.log
+          no_output_timeout: 3600s
+
+      - run:
+          name: parse test output
+          command: terratest_log_parser --testlog /tmp/logs/all.log --outputdir /tmp/logs
+          when: always
+
+      - store_artifacts:
+          path: /tmp/logs
+      - store_test_results:
+          path: /tmp/logs      
 
   deploy:
     <<: *defaults
@@ -64,16 +84,13 @@ workflows:
   version: 2
   build-and-test:
     jobs:
-      - build
       - test:
-          requires:
-            - build
           filters:
             branches:
               ignore: publish-amis
       - deploy:
           requires:
-            - build
+            - test
           filters:
             branches:
               only: publish-amis
@@ -88,7 +105,4 @@ workflows:
               only:
                 - master
     jobs:
-      - build
-      - test:
-          requires:
-            - build
+      - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,7 @@ jobs:
 
       - run:
           name: run tests
-          command: run-go-tests --path test --timeout 2h | tee /tmp/logs/all.log
+          command: run-go-tests --circle-ci-2 --path test --timeout 2h | tee /tmp/logs/all.log
           no_output_timeout: 3600s
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,8 +46,6 @@ jobs:
       - run:
           <<: *install_gruntwork_utils
                 
-      - run: echo 'export PATH=$HOME/terraform:$HOME/packer:$PATH' >> $BASH_ENV
-
       - run:
           name: create log directory
           command: mkdir -p /tmp/logs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,11 +21,11 @@ install_gruntwork_utils: &install_gruntwork_utils
     sudo -E gruntwork-install --binary-name "docs-generator" --repo "https://github.com/gruntwork-io/module-ci" --tag "v0.13.11"
     sudo -E gruntwork-install --binary-name "terratest_log_parser" --repo "https://github.com/gruntwork-io/terratest" --tag "${TERRATEST_LOG_PARSER_VERSION}"
     configure-environment-for-gruntwork-module \
-      --circle-ci-2-machine-executor \
       --terraform-version ${TERRAFORM_VERSION} \
       --terragrunt-version ${TERRAGRUNT_VERSION} \
       --packer-version ${PACKER_VERSION} \
       --use-go-dep \
+      --circle-ci-2 \
       --go-version ${GOLANG_VERSION} \
       --go-src-path test    
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,9 +43,19 @@ jobs:
     <<: *defaults
     steps:
       - checkout
+      
+      - restore_cache:
+          keys:
+            - dep-v2-{{ checksum "test/Gopkg.lock" }}
+
       - run:
           <<: *install_gruntwork_utils
-                
+
+      - save_cache:
+          key: dep-v2-{{ checksum "test/Gopkg.lock" }}
+          paths:
+            - /go/src/github.com/hashicorp/terraform-aws-nomad/test/vendor
+
       - run:
           name: create log directory
           command: mkdir -p /tmp/logs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-workspace_root: &workspace_root /go/src/github.com/hashicorp/terraform-aws-consul
+workspace_root: &workspace_root /go/src/github.com/hashicorp/terraform-aws-nomad
 defaults: &defaults
   working_directory: *workspace_root
   docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,6 @@
+workspace_root: &workspace_root /go/src/github.com/hashicorp/terraform-aws-consul
 defaults: &defaults
+  working_directory: *workspace_root
   docker:
     - image: 087285199408.dkr.ecr.us-east-1.amazonaws.com/circle-ci-test-image-base:latest
   #machine:
@@ -44,7 +46,9 @@ jobs:
     <<: *defaults
     steps:
       - checkout
-      
+      - attach_workspace:
+          at: *workspace_root
+
       - restore_cache:
           keys:
             - dep-v2-{{ checksum "test/Gopkg.lock" }}
@@ -56,6 +60,10 @@ jobs:
           key: dep-v2-{{ checksum "test/Gopkg.lock" }}
           paths:
             - /go/src/github.com/hashicorp/terraform-aws-nomad/test/vendor
+      
+      - persist_to_workspace:
+          root: *workspace_root
+          paths: test/vendor
 
       - run:
           name: create log directory

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,8 +3,6 @@ defaults: &defaults
   working_directory: *workspace_root
   docker:
     - image: 087285199408.dkr.ecr.us-east-1.amazonaws.com/circle-ci-test-image-base:latest
-  #machine:
-  #  image: circleci/classic:201711-01    
   environment:
     GRUNTWORK_INSTALLER_VERSION: v0.0.21
     TERRATEST_LOG_PARSER_VERSION: v0.17.4
@@ -21,7 +19,6 @@ install_gruntwork_utils: &install_gruntwork_utils
     curl -Ls https://raw.githubusercontent.com/gruntwork-io/gruntwork-installer/master/bootstrap-gruntwork-installer.sh | bash /dev/stdin --version "${GRUNTWORK_INSTALLER_VERSION}"
     sudo -E gruntwork-install --module-name "gruntwork-module-circleci-helpers" --repo "https://github.com/gruntwork-io/module-ci" --tag "${MODULE_CI_VERSION}"
     sudo -E gruntwork-install --binary-name "docs-generator" --repo "https://github.com/gruntwork-io/module-ci" --tag "v0.13.11"
-    # sudo -E gruntwork-install --binary-name "terratest_log_parser" --repo "https://github.com/gruntwork-io/terratest" --tag "${TERRATEST_LOG_PARSER_VERSION}"
     configure-environment-for-gruntwork-module \
       --terraform-version ${TERRAFORM_VERSION} \
       --terragrunt-version ${TERRAGRUNT_VERSION} \
@@ -73,11 +70,6 @@ jobs:
           name: run tests
           command: run-go-tests --circle-ci-2 --path test --timeout 2h | tee /tmp/logs/all.log
           no_output_timeout: 3600s
-
-      # - run:
-      #     name: parse test output
-      #     command: terratest_log_parser --testlog /tmp/logs/all.log --outputdir /tmp/logs
-      #     when: always
 
       - store_artifacts:
           path: /tmp/logs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,4 @@
-workspace_root: &workspace_root /go/src/github.com/hashicorp/terraform-aws-nomad
 defaults: &defaults
-  working_directory: *workspace_root
   docker:
     - image: 087285199408.dkr.ecr.us-east-1.amazonaws.com/circle-ci-test-image-base:latest
   #machine:
@@ -52,7 +50,6 @@ jobs:
             - dep-v2-{{ checksum "test/Gopkg.lock" }}
 
       - run:
-          <<: *defaults
           <<: *install_gruntwork_utils
 
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,8 @@
 defaults: &defaults
-  docker:
-    - image: 087285199408.dkr.ecr.us-east-1.amazonaws.com/circle-ci-test-image-base:latest
+  # docker:
+  #   - image: 087285199408.dkr.ecr.us-east-1.amazonaws.com/circle-ci-test-image-base:latest
+  machine:
+    image: circleci/classic:201711-01    
   environment:
     GRUNTWORK_INSTALLER_VERSION: v0.0.21
     TERRATEST_LOG_PARSER_VERSION: v0.17.4

--- a/examples/nomad-consul-separate-cluster/main.tf
+++ b/examples/nomad-consul-separate-cluster/main.tf
@@ -95,7 +95,7 @@ module "nomad_servers" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 module "consul_iam_policies_servers" {
-  source = "github.com/hashicorp/terraform-aws-consul//modules/consul-iam-policies?ref=v0.3.1"
+  source = "github.com/hashicorp/terraform-aws-consul//modules/consul-iam-policies?ref=v0.7.0"
 
   iam_role_id = module.nomad_servers.iam_role_id
 }
@@ -120,7 +120,7 @@ data "template_file" "user_data_nomad_server" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 module "consul_servers" {
-  source = "github.com/hashicorp/terraform-aws-consul//modules/consul-cluster?ref=v0.3.1"
+  source = "github.com/hashicorp/terraform-aws-consul//modules/consul-cluster?ref=v0.7.0"
 
   cluster_name  = "${var.consul_cluster_name}-server"
   cluster_size  = var.num_consul_servers
@@ -206,7 +206,7 @@ module "nomad_clients" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 module "consul_iam_policies_clients" {
-  source = "github.com/hashicorp/terraform-aws-consul//modules/consul-iam-policies?ref=v0.3.1"
+  source = "github.com/hashicorp/terraform-aws-consul//modules/consul-iam-policies?ref=v0.7.0"
 
   iam_role_id = module.nomad_clients.iam_role_id
 }

--- a/examples/nomad-consul-separate-cluster/main.tf
+++ b/examples/nomad-consul-separate-cluster/main.tf
@@ -74,7 +74,7 @@ module "nomad_servers" {
   max_size         = var.num_nomad_servers
   desired_capacity = var.num_nomad_servers
 
-  ami_id    = var.ami_id == "" ? data.aws_ami.nomad_consul.image_id : var.ami_id
+  ami_id    = var.ami_id == null ? data.aws_ami.nomad_consul.image_id : var.ami_id
   user_data = data.template_file.user_data_nomad_server.rendered
 
   vpc_id     = data.aws_vpc.default.id
@@ -130,7 +130,7 @@ module "consul_servers" {
   cluster_tag_key   = var.cluster_tag_key
   cluster_tag_value = var.consul_cluster_name
 
-  ami_id    = var.ami_id == "" ? data.aws_ami.nomad_consul.image_id : var.ami_id
+  ami_id    = var.ami_id == null ? data.aws_ami.nomad_consul.image_id : var.ami_id
   user_data = data.template_file.user_data_consul_server.rendered
 
   vpc_id     = data.aws_vpc.default.id
@@ -181,7 +181,7 @@ module "nomad_clients" {
   min_size         = var.num_nomad_clients
   max_size         = var.num_nomad_clients
   desired_capacity = var.num_nomad_clients
-  ami_id           = var.ami_id == "" ? data.aws_ami.nomad_consul.image_id : var.ami_id
+  ami_id           = var.ami_id == null ? data.aws_ami.nomad_consul.image_id : var.ami_id
   user_data        = data.template_file.user_data_nomad_client.rendered
   vpc_id           = data.aws_vpc.default.id
   subnet_ids       = data.aws_subnet_ids.default.ids

--- a/examples/nomad-consul-separate-cluster/main.tf
+++ b/examples/nomad-consul-separate-cluster/main.tf
@@ -12,10 +12,12 @@
 # Packer template in the Consul AWS Module.
 # ---------------------------------------------------------------------------------------------------------------------
 
-# Terraform 0.9.5 suffered from https://github.com/hashicorp/terraform/issues/14399, which causes this template the
-# conditionals in this template to fail.
+# ----------------------------------------------------------------------------------------------------------------------
+# REQUIRE A SPECIFIC TERRAFORM VERSION OR HIGHER
+# This module has been updated with 0.12 syntax, which means it is no longer compatible with any versions below 0.12.
+# ----------------------------------------------------------------------------------------------------------------------
 terraform {
-  required_version = ">= 0.9.3, != 0.9.5"
+  required_version = ">= 0.12"
 }
 
 # ---------------------------------------------------------------------------------------------------------------------
@@ -68,22 +70,22 @@ module "nomad_servers" {
   instance_type = "t2.micro"
 
   # You should typically use a fixed size of 3 or 5 for your Nomad server cluster
-  min_size         = "${var.num_nomad_servers}"
-  max_size         = "${var.num_nomad_servers}"
-  desired_capacity = "${var.num_nomad_servers}"
+  min_size         = var.num_nomad_servers
+  max_size         = var.num_nomad_servers
+  desired_capacity = var.num_nomad_servers
 
-  ami_id    = "${var.ami_id == "" ? data.aws_ami.nomad_consul.image_id : var.ami_id}"
-  user_data = "${data.template_file.user_data_nomad_server.rendered}"
+  ami_id    = var.ami_id == "" ? data.aws_ami.nomad_consul.image_id : var.ami_id
+  user_data = data.template_file.user_data_nomad_server.rendered
 
-  vpc_id     = "${data.aws_vpc.default.id}"
-  subnet_ids = "${data.aws_subnet_ids.default.ids}"
+  vpc_id     = data.aws_vpc.default.id
+  subnet_ids = data.aws_subnet_ids.default.ids
 
   # To make testing easier, we allow requests from any IP address here but in a production deployment, we strongly
   # recommend you limit this to the IP address ranges of known, trusted servers inside your VPC.
   allowed_ssh_cidr_blocks = ["0.0.0.0/0"]
 
   allowed_inbound_cidr_blocks = ["0.0.0.0/0"]
-  ssh_key_name                = "${var.ssh_key_name}"
+  ssh_key_name                = var.ssh_key_name
 }
 
 # ---------------------------------------------------------------------------------------------------------------------
@@ -95,7 +97,7 @@ module "nomad_servers" {
 module "consul_iam_policies_servers" {
   source = "github.com/hashicorp/terraform-aws-consul//modules/consul-iam-policies?ref=v0.3.1"
 
-  iam_role_id = "${module.nomad_servers.iam_role_id}"
+  iam_role_id = module.nomad_servers.iam_role_id
 }
 
 # ---------------------------------------------------------------------------------------------------------------------
@@ -104,12 +106,12 @@ module "consul_iam_policies_servers" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 data "template_file" "user_data_nomad_server" {
-  template = "${file("${path.module}/user-data-nomad-server.sh")}"
+  template = file("${path.module}/user-data-nomad-server.sh")
 
-  vars {
-    num_servers       = "${var.num_nomad_servers}"
-    cluster_tag_key   = "${var.cluster_tag_key}"
-    cluster_tag_value = "${var.consul_cluster_name}"
+  vars = {
+    num_servers       = var.num_nomad_servers
+    cluster_tag_key   = var.cluster_tag_key
+    cluster_tag_value = var.consul_cluster_name
   }
 }
 
@@ -121,25 +123,25 @@ module "consul_servers" {
   source = "github.com/hashicorp/terraform-aws-consul//modules/consul-cluster?ref=v0.3.1"
 
   cluster_name  = "${var.consul_cluster_name}-server"
-  cluster_size  = "${var.num_consul_servers}"
+  cluster_size  = var.num_consul_servers
   instance_type = "t2.micro"
 
   # The EC2 Instances will use these tags to automatically discover each other and form a cluster
-  cluster_tag_key   = "${var.cluster_tag_key}"
-  cluster_tag_value = "${var.consul_cluster_name}"
+  cluster_tag_key   = var.cluster_tag_key
+  cluster_tag_value = var.consul_cluster_name
 
-  ami_id    = "${var.ami_id == "" ? data.aws_ami.nomad_consul.image_id : var.ami_id}"
-  user_data = "${data.template_file.user_data_consul_server.rendered}"
+  ami_id    = var.ami_id == "" ? data.aws_ami.nomad_consul.image_id : var.ami_id
+  user_data = data.template_file.user_data_consul_server.rendered
 
-  vpc_id     = "${data.aws_vpc.default.id}"
-  subnet_ids = "${data.aws_subnet_ids.default.ids}"
+  vpc_id     = data.aws_vpc.default.id
+  subnet_ids = data.aws_subnet_ids.default.ids
 
   # To make testing easier, we allow Consul and SSH requests from any IP address here but in a production
   # deployment, we strongly recommend you limit this to the IP address ranges of known, trusted servers inside your VPC.
   allowed_ssh_cidr_blocks = ["0.0.0.0/0"]
 
   allowed_inbound_cidr_blocks = ["0.0.0.0/0"]
-  ssh_key_name                = "${var.ssh_key_name}"
+  ssh_key_name                = var.ssh_key_name
 }
 
 # ---------------------------------------------------------------------------------------------------------------------
@@ -148,11 +150,11 @@ module "consul_servers" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 data "template_file" "user_data_consul_server" {
-  template = "${file("${path.module}/user-data-consul-server.sh")}"
+  template = file("${path.module}/user-data-consul-server.sh")
 
-  vars {
-    cluster_tag_key   = "${var.cluster_tag_key}"
-    cluster_tag_value = "${var.consul_cluster_name}"
+  vars = {
+    cluster_tag_key   = var.cluster_tag_key
+    cluster_tag_value = var.consul_cluster_name
   }
 }
 
@@ -171,27 +173,30 @@ module "nomad_clients" {
 
   # Give the clients a different tag so they don't try to join the server cluster
   cluster_tag_key   = "nomad-clients"
-  cluster_tag_value = "${var.nomad_cluster_name}"
+  cluster_tag_value = var.nomad_cluster_name
 
   # To keep the example simple, we are using a fixed-size cluster. In real-world usage, you could use auto scaling
   # policies to dynamically resize the cluster in response to load.
 
-  min_size         = "${var.num_nomad_clients}"
-  max_size         = "${var.num_nomad_clients}"
-  desired_capacity = "${var.num_nomad_clients}"
-  ami_id           = "${var.ami_id == "" ? data.aws_ami.nomad_consul.image_id : var.ami_id}"
-  user_data        = "${data.template_file.user_data_nomad_client.rendered}"
-  vpc_id           = "${data.aws_vpc.default.id}"
-  subnet_ids       = "${data.aws_subnet_ids.default.ids}"
+  min_size         = var.num_nomad_clients
+  max_size         = var.num_nomad_clients
+  desired_capacity = var.num_nomad_clients
+  ami_id           = var.ami_id == "" ? data.aws_ami.nomad_consul.image_id : var.ami_id
+  user_data        = data.template_file.user_data_nomad_client.rendered
+  vpc_id           = data.aws_vpc.default.id
+  subnet_ids       = data.aws_subnet_ids.default.ids
+
   # To make testing easier, we allow Consul and SSH requests from any IP address here but in a production
   # deployment, we strongly recommend you limit this to the IP address ranges of known, trusted servers inside your VPC.
-  allowed_ssh_cidr_blocks = ["0.0.0.0/0"]
+  allowed_ssh_cidr_blocks     = ["0.0.0.0/0"]
   allowed_inbound_cidr_blocks = ["0.0.0.0/0"]
-  ssh_key_name                = "${var.ssh_key_name}"
-  ebs_block_devices = [{
-    "device_name" = "/dev/xvde"
-    "volume_size" = "10"
-  }]
+  ssh_key_name                = var.ssh_key_name
+  ebs_block_devices = [
+    {
+      "device_name" = "/dev/xvde"
+      "volume_size" = "10"
+    },
+  ]
 }
 
 # ---------------------------------------------------------------------------------------------------------------------
@@ -203,7 +208,7 @@ module "nomad_clients" {
 module "consul_iam_policies_clients" {
   source = "github.com/hashicorp/terraform-aws-consul//modules/consul-iam-policies?ref=v0.3.1"
 
-  iam_role_id = "${module.nomad_clients.iam_role_id}"
+  iam_role_id = module.nomad_clients.iam_role_id
 }
 
 # ---------------------------------------------------------------------------------------------------------------------
@@ -212,11 +217,11 @@ module "consul_iam_policies_clients" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 data "template_file" "user_data_nomad_client" {
-  template = "${file("${path.module}/user-data-nomad-client.sh")}"
+  template = file("${path.module}/user-data-nomad-client.sh")
 
-  vars {
-    cluster_tag_key   = "${var.cluster_tag_key}"
-    cluster_tag_value = "${var.consul_cluster_name}"
+  vars = {
+    cluster_tag_key   = var.cluster_tag_key
+    cluster_tag_value = var.consul_cluster_name
   }
 }
 
@@ -232,7 +237,9 @@ data "aws_vpc" "default" {
 }
 
 data "aws_subnet_ids" "default" {
-  vpc_id = "${data.aws_vpc.default.id}"
+  vpc_id = data.aws_vpc.default.id
 }
 
-data "aws_region" "current" {}
+data "aws_region" "current" {
+}
+

--- a/examples/nomad-consul-separate-cluster/outputs.tf
+++ b/examples/nomad-consul-separate-cluster/outputs.tf
@@ -1,83 +1,84 @@
 output "num_nomad_servers" {
-  value = "${module.nomad_servers.cluster_size}"
+  value = module.nomad_servers.cluster_size
 }
 
 output "asg_name_nomad_servers" {
-  value = "${module.nomad_servers.asg_name}"
+  value = module.nomad_servers.asg_name
 }
 
 output "launch_config_name_nomad_servers" {
-  value = "${module.nomad_servers.launch_config_name}"
+  value = module.nomad_servers.launch_config_name
 }
 
 output "iam_role_arn_nomad_servers" {
-  value = "${module.nomad_servers.iam_role_arn}"
+  value = module.nomad_servers.iam_role_arn
 }
 
 output "iam_role_id_nomad_servers" {
-  value = "${module.nomad_servers.iam_role_id}"
+  value = module.nomad_servers.iam_role_id
 }
 
 output "security_group_id_nomad_servers" {
-  value = "${module.nomad_servers.security_group_id}"
+  value = module.nomad_servers.security_group_id
 }
 
 output "num_consul_servers" {
-  value = "${module.consul_servers.cluster_size}"
+  value = module.consul_servers.cluster_size
 }
 
 output "asg_name_consul_servers" {
-  value = "${module.consul_servers.asg_name}"
+  value = module.consul_servers.asg_name
 }
 
 output "launch_config_name_consul_servers" {
-  value = "${module.consul_servers.launch_config_name}"
+  value = module.consul_servers.launch_config_name
 }
 
 output "iam_role_arn_consul_servers" {
-  value = "${module.consul_servers.iam_role_arn}"
+  value = module.consul_servers.iam_role_arn
 }
 
 output "iam_role_id_consul_servers" {
-  value = "${module.consul_servers.iam_role_id}"
+  value = module.consul_servers.iam_role_id
 }
 
 output "security_group_id_consul_servers" {
-  value = "${module.consul_servers.security_group_id}"
+  value = module.consul_servers.security_group_id
 }
 
 output "num_nomad_clients" {
-  value = "${module.nomad_clients.cluster_size}"
+  value = module.nomad_clients.cluster_size
 }
 
 output "asg_name_nomad_clients" {
-  value = "${module.nomad_clients.asg_name}"
+  value = module.nomad_clients.asg_name
 }
 
 output "launch_config_name_nomad_clients" {
-  value = "${module.nomad_clients.launch_config_name}"
+  value = module.nomad_clients.launch_config_name
 }
 
 output "iam_role_arn_nomad_clients" {
-  value = "${module.nomad_clients.iam_role_arn}"
+  value = module.nomad_clients.iam_role_arn
 }
 
 output "iam_role_id_nomad_clients" {
-  value = "${module.nomad_clients.iam_role_id}"
+  value = module.nomad_clients.iam_role_id
 }
 
 output "security_group_id_nomad_clients" {
-  value = "${module.nomad_clients.security_group_id}"
+  value = module.nomad_clients.security_group_id
 }
 
 output "aws_region" {
-  value = "${data.aws_region.current.name}"
+  value = data.aws_region.current.name
 }
 
 output "nomad_servers_cluster_tag_key" {
-  value = "${module.nomad_servers.cluster_tag_key}"
+  value = module.nomad_servers.cluster_tag_key
 }
 
 output "nomad_servers_cluster_tag_value" {
-  value = "${module.nomad_servers.cluster_tag_value}"
+  value = module.nomad_servers.cluster_tag_value
 }
+

--- a/examples/nomad-consul-separate-cluster/variables.tf
+++ b/examples/nomad-consul-separate-cluster/variables.tf
@@ -21,49 +21,49 @@
 
 variable "ami_id" {
   description = "The ID of the AMI to run in the cluster. This should be an AMI built from the Packer template under examples/nomad-consul-ami/nomad-consul.json. If no AMI is specified, the template will 'just work' by using the example public AMIs. WARNING! Do not use the example AMIs in a production setting!"
-  type=string
+  type        = string
   default     = ""
 }
 
 variable "nomad_cluster_name" {
   description = "What to name the Nomad cluster and all of its associated resources"
-  type=string
+  type        = string
   default     = "nomad-example"
 }
 
 variable "consul_cluster_name" {
   description = "What to name the Consul cluster and all of its associated resources"
-  type=string
+  type        = string
   default     = "consul-example"
 }
 
 variable "num_nomad_servers" {
   description = "The number of Nomad server nodes to deploy. We strongly recommend using 3 or 5."
-  type=number
+  type        = number
   default     = 3
 }
 
 variable "num_nomad_clients" {
   description = "The number of Nomad client nodes to deploy. You can deploy as many as you need to run your jobs."
-  type=number
+  type        = number
   default     = 6
 }
 
 variable "num_consul_servers" {
   description = "The number of Consul server nodes to deploy. We strongly recommend using 3 or 5."
-  type=number
+  type        = number
   default     = 3
 }
 
 variable "cluster_tag_key" {
   description = "The tag the Consul EC2 Instances will look for to automatically discover each other and form a cluster."
-  type=string
+  type        = string
   default     = "consul-servers"
 }
 
 variable "ssh_key_name" {
   description = "The name of an EC2 Key Pair that can be used to SSH to the EC2 Instances in this cluster. Set to an empty string to not associate a Key Pair."
-  type=string
+  type        = string
   default     = ""
 }
 

--- a/examples/nomad-consul-separate-cluster/variables.tf
+++ b/examples/nomad-consul-separate-cluster/variables.tf
@@ -21,40 +21,49 @@
 
 variable "ami_id" {
   description = "The ID of the AMI to run in the cluster. This should be an AMI built from the Packer template under examples/nomad-consul-ami/nomad-consul.json. If no AMI is specified, the template will 'just work' by using the example public AMIs. WARNING! Do not use the example AMIs in a production setting!"
+  type=string
   default     = ""
 }
 
 variable "nomad_cluster_name" {
   description = "What to name the Nomad cluster and all of its associated resources"
+  type=string
   default     = "nomad-example"
 }
 
 variable "consul_cluster_name" {
   description = "What to name the Consul cluster and all of its associated resources"
+  type=string
   default     = "consul-example"
 }
 
 variable "num_nomad_servers" {
   description = "The number of Nomad server nodes to deploy. We strongly recommend using 3 or 5."
+  type=number
   default     = 3
 }
 
 variable "num_nomad_clients" {
   description = "The number of Nomad client nodes to deploy. You can deploy as many as you need to run your jobs."
+  type=number
   default     = 6
 }
 
 variable "num_consul_servers" {
   description = "The number of Consul server nodes to deploy. We strongly recommend using 3 or 5."
+  type=number
   default     = 3
 }
 
 variable "cluster_tag_key" {
   description = "The tag the Consul EC2 Instances will look for to automatically discover each other and form a cluster."
+  type=string
   default     = "consul-servers"
 }
 
 variable "ssh_key_name" {
   description = "The name of an EC2 Key Pair that can be used to SSH to the EC2 Instances in this cluster. Set to an empty string to not associate a Key Pair."
+  type=string
   default     = ""
 }
+

--- a/examples/nomad-consul-separate-cluster/variables.tf
+++ b/examples/nomad-consul-separate-cluster/variables.tf
@@ -22,7 +22,7 @@
 variable "ami_id" {
   description = "The ID of the AMI to run in the cluster. This should be an AMI built from the Packer template under examples/nomad-consul-ami/nomad-consul.json. If no AMI is specified, the template will 'just work' by using the example public AMIs. WARNING! Do not use the example AMIs in a production setting!"
   type        = string
-  default     = ""
+  default     = null
 }
 
 variable "nomad_cluster_name" {
@@ -62,8 +62,8 @@ variable "cluster_tag_key" {
 }
 
 variable "ssh_key_name" {
-  description = "The name of an EC2 Key Pair that can be used to SSH to the EC2 Instances in this cluster. Set to an empty string to not associate a Key Pair."
+  description = "The name of an EC2 Key Pair that can be used to SSH to the EC2 Instances in this cluster. Set to null to not associate a Key Pair."
   type        = string
-  default     = ""
+  default     = null
 }
 

--- a/main.tf
+++ b/main.tf
@@ -68,7 +68,7 @@ module "servers" {
   cluster_tag_key   = var.cluster_tag_key
   cluster_tag_value = var.cluster_tag_value
 
-  ami_id    = var.ami_id == "" ? data.aws_ami.nomad_consul.image_id : var.ami_id
+  ami_id    = var.ami_id == null ? data.aws_ami.nomad_consul.image_id : var.ami_id
   user_data = data.template_file.user_data_server.rendered
 
   vpc_id     = data.aws_vpc.default.id
@@ -148,7 +148,7 @@ module "clients" {
   max_size         = var.num_clients
   desired_capacity = var.num_clients
 
-  ami_id    = var.ami_id == "" ? data.aws_ami.nomad_consul.image_id : var.ami_id
+  ami_id    = var.ami_id == null ? data.aws_ami.nomad_consul.image_id : var.ami_id
   user_data = data.template_file.user_data_client.rendered
 
   vpc_id     = data.aws_vpc.default.id

--- a/main.tf
+++ b/main.tf
@@ -8,10 +8,12 @@
 # ami_id input variable is built from the examples/nomad-consul-ami/nomad-consul.json Packer template.
 # ---------------------------------------------------------------------------------------------------------------------
 
-# Terraform 0.9.5 suffered from https://github.com/hashicorp/terraform/issues/14399, which causes this template the
-# conditionals in this template to fail.
+# ----------------------------------------------------------------------------------------------------------------------
+# REQUIRE A SPECIFIC TERRAFORM VERSION OR HIGHER
+# This module has been updated with 0.12 syntax, which means it is no longer compatible with any versions below 0.12.
+# ----------------------------------------------------------------------------------------------------------------------
 terraform {
-  required_version = ">= 0.9.3, != 0.9.5"
+  required_version = ">= 0.12"
 }
 
 # ---------------------------------------------------------------------------------------------------------------------
@@ -56,28 +58,28 @@ data "aws_ami" "nomad_consul" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 module "servers" {
-  source = "github.com/hashicorp/terraform-aws-consul//modules/consul-cluster?ref=v0.3.1"
+  source = "github.com/hashicorp/terraform-aws-consul//modules/consul-cluster?ref=v0.7.0"
 
   cluster_name  = "${var.cluster_name}-server"
-  cluster_size  = "${var.num_servers}"
+  cluster_size  = var.num_servers
   instance_type = "t2.micro"
 
   # The EC2 Instances will use these tags to automatically discover each other and form a cluster
-  cluster_tag_key   = "${var.cluster_tag_key}"
-  cluster_tag_value = "${var.cluster_tag_value}"
+  cluster_tag_key   = var.cluster_tag_key
+  cluster_tag_value = var.cluster_tag_value
 
-  ami_id    = "${var.ami_id == "" ? data.aws_ami.nomad_consul.image_id : var.ami_id}"
-  user_data = "${data.template_file.user_data_server.rendered}"
+  ami_id    = var.ami_id == "" ? data.aws_ami.nomad_consul.image_id : var.ami_id
+  user_data = data.template_file.user_data_server.rendered
 
-  vpc_id     = "${data.aws_vpc.default.id}"
-  subnet_ids = "${data.aws_subnet_ids.default.ids}"
+  vpc_id     = data.aws_vpc.default.id
+  subnet_ids = data.aws_subnet_ids.default.ids
 
   # To make testing easier, we allow requests from any IP address here but in a production deployment, we strongly
   # recommend you limit this to the IP address ranges of known, trusted servers inside your VPC.
   allowed_ssh_cidr_blocks = ["0.0.0.0/0"]
 
   allowed_inbound_cidr_blocks = ["0.0.0.0/0"]
-  ssh_key_name                = "${var.ssh_key_name}"
+  ssh_key_name                = var.ssh_key_name
 
   tags = [
     {
@@ -102,7 +104,7 @@ module "nomad_security_group_rules" {
 
   # To make testing easier, we allow requests from any IP address here but in a production deployment, we strongly
   # recommend you limit this to the IP address ranges of known, trusted servers inside your VPC.
-  security_group_id = "${module.servers.security_group_id}"
+  security_group_id = module.servers.security_group_id
 
   allowed_inbound_cidr_blocks = ["0.0.0.0/0"]
 }
@@ -113,12 +115,12 @@ module "nomad_security_group_rules" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 data "template_file" "user_data_server" {
-  template = "${file("${path.module}/examples/root-example/user-data-server.sh")}"
+  template = file("${path.module}/examples/root-example/user-data-server.sh")
 
-  vars {
-    cluster_tag_key   = "${var.cluster_tag_key}"
-    cluster_tag_value = "${var.cluster_tag_value}"
-    num_servers       = "${var.num_servers}"
+  vars = {
+    cluster_tag_key   = var.cluster_tag_key
+    cluster_tag_value = var.cluster_tag_value
+    num_servers       = var.num_servers
   }
 }
 
@@ -133,38 +135,38 @@ module "clients" {
   source = "./modules/nomad-cluster"
 
   cluster_name  = "${var.cluster_name}-client"
-  instance_type = "${var.instance_type}"
+  instance_type = var.instance_type
 
   # Give the clients a different tag so they don't try to join the server cluster
   cluster_tag_key   = "nomad-clients"
-  cluster_tag_value = "${var.cluster_name}"
+  cluster_tag_value = var.cluster_name
 
   # To keep the example simple, we are using a fixed-size cluster. In real-world usage, you could use auto scaling
   # policies to dynamically resize the cluster in response to load.
-  min_size = "${var.num_clients}"
+  min_size = var.num_clients
 
-  max_size         = "${var.num_clients}"
-  desired_capacity = "${var.num_clients}"
+  max_size         = var.num_clients
+  desired_capacity = var.num_clients
 
-  ami_id    = "${var.ami_id == "" ? data.aws_ami.nomad_consul.image_id : var.ami_id}"
-  user_data = "${data.template_file.user_data_client.rendered}"
+  ami_id    = var.ami_id == "" ? data.aws_ami.nomad_consul.image_id : var.ami_id
+  user_data = data.template_file.user_data_client.rendered
 
-  vpc_id     = "${data.aws_vpc.default.id}"
-  subnet_ids = "${data.aws_subnet_ids.default.ids}"
+  vpc_id     = data.aws_vpc.default.id
+  subnet_ids = data.aws_subnet_ids.default.ids
 
   # To make testing easier, we allow Consul and SSH requests from any IP address here but in a production
   # deployment, we strongly recommend you limit this to the IP address ranges of known, trusted servers inside your VPC.
   allowed_ssh_cidr_blocks = ["0.0.0.0/0"]
 
   allowed_inbound_cidr_blocks = ["0.0.0.0/0"]
-  ssh_key_name                = "${var.ssh_key_name}"
+  ssh_key_name                = var.ssh_key_name
 
   tags = [
     {
       key                 = "Environment"
       value               = "development"
       propagate_at_launch = true
-    },
+    }
   ]
 }
 
@@ -175,9 +177,9 @@ module "clients" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 module "consul_iam_policies" {
-  source = "github.com/hashicorp/terraform-aws-consul//modules/consul-iam-policies?ref=v0.3.1"
+  source = "github.com/hashicorp/terraform-aws-consul//modules/consul-iam-policies?ref=v0.7.0"
 
-  iam_role_id = "${module.clients.iam_role_id}"
+  iam_role_id = module.clients.iam_role_id
 }
 
 # ---------------------------------------------------------------------------------------------------------------------
@@ -186,11 +188,11 @@ module "consul_iam_policies" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 data "template_file" "user_data_client" {
-  template = "${file("${path.module}/examples/root-example/user-data-client.sh")}"
+  template = file("${path.module}/examples/root-example/user-data-client.sh")
 
-  vars {
-    cluster_tag_key   = "${var.cluster_tag_key}"
-    cluster_tag_value = "${var.cluster_tag_value}"
+  vars = {
+    cluster_tag_key   = var.cluster_tag_key
+    cluster_tag_value = var.cluster_tag_value
   }
 }
 
@@ -202,12 +204,14 @@ data "template_file" "user_data_client" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 data "aws_vpc" "default" {
-  default = "${var.vpc_id == "" ? true : false}"
-  id      = "${var.vpc_id}"
+  default = var.vpc_id == "" ? true : false
+  id      = var.vpc_id
 }
 
 data "aws_subnet_ids" "default" {
-  vpc_id = "${data.aws_vpc.default.id}"
+  vpc_id = data.aws_vpc.default.id
 }
 
-data "aws_region" "current" {}
+data "aws_region" "current" {
+}
+

--- a/modules/nomad-cluster/README.md
+++ b/modules/nomad-cluster/README.md
@@ -9,8 +9,6 @@ Note that this module assumes you have a separate [Consul](https://www.consul.io
 to run Consul and Nomad in the same cluster, instead of using this module, see the [Deploy Nomad and Consul in the same
 cluster documentation](https://github.com/hashicorp/terraform-aws-nomad/tree/master/README.md#deploy-nomad-and-consul-in-the-same-cluster).
 
-
-
 ## How do you use this module?
 
 This folder defines a [Terraform module](https://www.terraform.io/docs/modules/usage.html), which you can use in your
@@ -38,17 +36,17 @@ module "nomad_cluster" {
 
 Note the following parameters:
 
-* `source`: Use this parameter to specify the URL of the nomad-cluster module. The double slash (`//`) is intentional
+- `source`: Use this parameter to specify the URL of the nomad-cluster module. The double slash (`//`) is intentional
   and required. Terraform uses it to specify subfolders within a Git repo (see [module
   sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
   this repo. That way, instead of using the latest version of this module from the `master` branch, which
   will change every time you run Terraform, you're using a fixed version of the repo.
 
-* `ami_id`: Use this parameter to specify the ID of a Nomad [Amazon Machine Image
+- `ami_id`: Use this parameter to specify the ID of a Nomad [Amazon Machine Image
   (AMI)](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AMIs.html) to deploy on each server in the cluster. You
   should install Nomad in this AMI using the scripts in the [install-nomad](https://github.com/hashicorp/terraform-aws-nomad/tree/master/modules/install-nomad) module.
 
-* `user_data`: Use this parameter to specify a [User
+- `user_data`: Use this parameter to specify a [User
   Data](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/user-data.html#user-data-shell-scripts) script that each
   server will run during boot. This is where you can use the [run-nomad script](https://github.com/hashicorp/terraform-aws-nomad/tree/master/modules/run-nomad) to configure and
   run Nomad. The `run-nomad` script is one of the scripts installed by the [install-nomad](https://github.com/hashicorp/terraform-aws-nomad/tree/master/modules/install-nomad)
@@ -59,10 +57,6 @@ You can find the other parameters in [vars.tf](vars.tf).
 Check out the [nomad-consul-separate-cluster example](https://github.com/hashicorp/terraform-aws-nomad/tree/master/examples/nomad-consul-separate-cluster example) for working
 sample code. Note that if you want to run Nomad and Consul on the same cluster, see the [nomad-consul-colocated-cluster
 example](https://github.com/hashicorp/terraform-aws-nomad/tree/master/MAIN.md example) instead.
-
-
-
-
 
 ## How do you connect to the Nomad cluster?
 
@@ -129,17 +123,12 @@ And to submit a job called `example.nomad`:
 ==> Evaluation "0d159869" finished with status "complete"
 ```
 
-
-
 ### Using the Nomad agent on another EC2 Instance
 
 For production usage, your EC2 Instances should be running the [Nomad
 agent](https://www.nomadproject.io/docs/agent/index.html). The agent nodes should discover the Nomad server nodes
 automatically using Consul. Check out the [Service Discovery
 documentation](https://www.nomadproject.io/docs/service-discovery/index.html) for details.
-
-
-
 
 ## What's included in this module?
 
@@ -149,10 +138,9 @@ This module creates the following architecture:
 
 This architecture consists of the following resources:
 
-* [Auto Scaling Group](#auto-scaling-group)
-* [Security Group](#security-group)
-* [IAM Role and Permissions](#iam-role-and-permissions)
-
+- [Auto Scaling Group](#auto-scaling-group)
+- [Security Group](#security-group)
+- [IAM Role and Permissions](#iam-role-and-permissions)
 
 ### Auto Scaling Group
 
@@ -162,19 +150,17 @@ Zones](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availabi
 Instances should be running an AMI that has had Nomad installed via the [install-nomad](https://github.com/hashicorp/terraform-aws-nomad/tree/master/modules/install-nomad)
 module. You pass in the ID of the AMI to run using the `ami_id` input parameter.
 
-
 ### Security Group
 
 Each EC2 Instance in the ASG has a Security Group that allows:
 
-* All outbound requests
-* All the inbound ports specified in the [Nomad
+- All outbound requests
+- All the inbound ports specified in the [Nomad
   documentation](https://www.nomadproject.io/docs/agent/configuration/index.html#ports)
 
 The Security Group ID is exported as an output variable if you need to add additional rules.
 
 Check out the [Security section](#security) for more details.
-
 
 ### IAM Role and Permissions
 
@@ -183,10 +169,6 @@ We give this IAM role a small set of IAM permissions that each EC2 Instance can 
 Instances in its ASG and form a cluster with them.
 
 The IAM Role ARN is exported as an output variable if you need to add additional permissions.
-
-
-
-
 
 ## How do you roll out updates?
 
@@ -201,15 +183,15 @@ NOT actually deploy those new instances. To make that happen, you should do the 
 
 1. Issue an API call to one of the old Instances in the ASG to have it leave gracefully. E.g.:
 
-    ```
-    nomad server-force-leave -address=<OLD_INSTANCE_IP>:4646
-    ```
+   ```
+   nomad server-force-leave -address=<OLD_INSTANCE_IP>:4646
+   ```
 
 1. Once the instance has left the cluster, terminate it:
 
-    ```
-    aws ec2 terminate-instances --instance-ids <OLD_INSTANCE_ID>
-    ```
+   ```
+   aws ec2 terminate-instances --instance-ids <OLD_INSTANCE_ID>
+   ```
 
 1. After a minute or two, the ASG should automatically launch a new Instance, with the new AMI, to replace the old one.
 
@@ -218,10 +200,6 @@ NOT actually deploy those new instances. To make that happen, you should do the 
 1. Repeat these steps for each of the other old Instances in the ASG.
 
 We will add a script in the future to automate this process (PRs are welcome!).
-
-
-
-
 
 ## What happens if a node crashes?
 
@@ -234,10 +212,6 @@ There are two ways a Nomad node may go down:
    command](https://www.nomadproject.io/docs/commands/server-force-leave.html). We may add a script to do this
    automatically in the future. For more info, see the [Nomad Outage
    documentation](https://www.nomadproject.io/guides/outage.html).
-
-
-
-
 
 ## How do you connect load balancers to the Auto Scaling Group (ASG)?
 
@@ -258,8 +232,8 @@ module "nomad" {
 
 # Create a new load balancer attachment
 resource "aws_autoscaling_attachment" "asg_attachment_bar" {
-  autoscaling_group_name = "${module.nomad.asg_name}"
-  alb_target_group_arn   = "${aws_alb_target_group.test.arn}"
+  autoscaling_group_name = module.nomad.asg_name
+  alb_target_group_arn   = aws_alb_target_group.test.arn
 }
 ```
 
@@ -279,14 +253,10 @@ module "nomad" {
 
 # Create a new load balancer attachment
 resource "aws_autoscaling_attachment" "asg_attachment_bar" {
-  autoscaling_group_name = "${module.nomad.asg_name}"
-  elb                    = "${aws_elb.bar.id}"
+  autoscaling_group_name = module.nomad.asg_name
+  elb                    = aws_elb.bar.id
 }
 ```
-
-
-
-
 
 ## Security
 
@@ -298,12 +268,10 @@ Here are some of the main security considerations to keep in mind when using thi
 1. [Security groups](#security-groups)
 1. [SSH access](#ssh-access)
 
-
 ### Encryption in transit
 
 Nomad can encrypt all of its network traffic. For instructions on enabling network encryption, have a look at the
 [How do you handle encryption documentation](https://github.com/hashicorp/terraform-aws-nomad/tree/master/modules/run-nomad#how-do-you-handle-encryption).
-
 
 ### Encryption at rest
 
@@ -312,27 +280,23 @@ rest, you must enable encryption in your Nomad AMI. If you're creating the AMI u
 the [nomad-consul-ami example](https://github.com/hashicorp/terraform-aws-nomad/tree/master/examples/nomad-consul-ami)), you need to set the [encrypt_boot
 parameter](https://www.packer.io/docs/builders/amazon-ebs.html#encrypt_boot) to `true`.
 
-
 ### Dedicated instances
 
 If you wish to use dedicated instances, you can set the `tenancy` parameter to `"dedicated"` in this module.
-
 
 ### Security groups
 
 This module attaches a security group to each EC2 Instance that allows inbound requests as follows:
 
-* **Nomad**: For all the [ports used by Nomad](https://www.nomadproject.io/docs/agent/configuration/index.html#ports),
+- **Nomad**: For all the [ports used by Nomad](https://www.nomadproject.io/docs/agent/configuration/index.html#ports),
   you can use the `allowed_inbound_cidr_blocks` parameter to control the list of
   [CIDR blocks](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing) that will be allowed access.
 
-* **SSH**: For the SSH port (default: 22), you can use the `allowed_ssh_cidr_blocks` parameter to control the list of
+- **SSH**: For the SSH port (default: 22), you can use the `allowed_ssh_cidr_blocks` parameter to control the list of
   [CIDR blocks](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing) that will be allowed access.
 
 Note that all the ports mentioned above are configurable via the `xxx_port` variables (e.g. `http_port`). See
 [vars.tf](vars.tf) for the full list.
-
-
 
 ### SSH access
 
@@ -340,19 +304,14 @@ You can associate an [EC2 Key Pair](http://docs.aws.amazon.com/AWSEC2/latest/Use
 of the EC2 Instances in this cluster by specifying the Key Pair's name in the `ssh_key_name` variable. If you don't
 want to associate a Key Pair with these servers, set `ssh_key_name` to an empty string.
 
-
-
-
-
 ## What's NOT included in this module?
 
 This module does NOT handle the following items, which you may want to provide on your own:
 
-* [Consul](#consul)
-* [Monitoring, alerting, log aggregation](#monitoring-alerting-log-aggregation)
-* [VPCs, subnets, route tables](#vpcs-subnets-route-tables)
-* [DNS entries](#dns-entries)
-
+- [Consul](#consul)
+- [Monitoring, alerting, log aggregation](#monitoring-alerting-log-aggregation)
+- [VPCs, subnets, route tables](#vpcs-subnets-route-tables)
+- [DNS entries](#dns-entries)
 
 ### Consul
 
@@ -360,13 +319,11 @@ This module assumes you already have Consul deployed in a separate cluster. If y
 same cluster, instead of using this module, see the [Deploy Nomad and Consul in the same cluster
 documentation](https://github.com/hashicorp/terraform-aws-nomad/tree/master/README.md#deploy-nomad-and-consul-in-the-same-cluster).
 
-
 ### Monitoring, alerting, log aggregation
 
 This module does not include anything for monitoring, alerting, or log aggregation. All ASGs and EC2 Instances come
 with limited [CloudWatch](https://aws.amazon.com/cloudwatch/) metrics built-in, but beyond that, you will have to
 provide your own solutions.
-
 
 ### VPCs, subnets, route tables
 
@@ -374,9 +331,6 @@ This module assumes you've already created your network topology (VPC, subnets, 
 pass in the the relevant info about your network topology (e.g. `vpc_id`, `subnet_ids`) as input variables to this
 module.
 
-
 ### DNS entries
 
 This module does not create any DNS entries for Nomad (e.g. in Route 53).
-
-

--- a/modules/nomad-cluster/main.tf
+++ b/modules/nomad-cluster/main.tf
@@ -76,7 +76,6 @@ resource "aws_launch_configuration" "launch_configuration" {
 
     content {
       device_name           = ebs_block_device.value["device_name"]
-      volume_type           = ebs_block_device.value["volume_type"]
       volume_size           = ebs_block_device.value["volume_size"]
       iops                  = lookup(ebs_block_device.value, "iops", null)
       encrypted             = lookup(ebs_block_device.value, "encrypted", null)

--- a/modules/nomad-cluster/main.tf
+++ b/modules/nomad-cluster/main.tf
@@ -26,21 +26,27 @@ resource "aws_autoscaling_group" "autoscaling_group" {
   health_check_grace_period = var.health_check_grace_period
   wait_for_capacity_timeout = var.wait_for_capacity_timeout
 
-  tags = flatten(
-    [
-      {
-        key                 = "Name"
-        value               = var.cluster_name
-        propagate_at_launch = true
-      },
-      {
-        key                 = var.cluster_tag_key
-        value               = var.cluster_tag_value
-        propagate_at_launch = true
-      },
-      var.tags,
-    ]
-  )
+  tag {
+    key                 = "Name"
+    value               = var.cluster_name
+    propagate_at_launch = true
+  }
+  
+  tag {
+    key                 = var.cluster_tag_key
+    value               = var.cluster_tag_value
+    propagate_at_launch = true
+  }
+
+  dynamic "tag" {
+    for_each = var.tags
+
+    content {
+      key                 = tag.key
+      value               = tag.value
+      propagate_at_launch = tag.propagate_at_launch
+    }
+  }
 }
 
 # ---------------------------------------------------------------------------------------------------------------------

--- a/modules/nomad-cluster/main.tf
+++ b/modules/nomad-cluster/main.tf
@@ -42,9 +42,9 @@ resource "aws_autoscaling_group" "autoscaling_group" {
     for_each = var.tags
 
     content {
-      key                 = tag.key
-      value               = tag.value
-      propagate_at_launch = tag.propagate_at_launch
+      key                 = tag.value["key"]
+      value               = tag.value["value"]
+      propagate_at_launch = tag.value["propagate_at_launch"]
     }
   }
 }

--- a/modules/nomad-cluster/outputs.tf
+++ b/modules/nomad-cluster/outputs.tf
@@ -1,31 +1,32 @@
 output "asg_name" {
-  value = "${aws_autoscaling_group.autoscaling_group.name}"
+  value = aws_autoscaling_group.autoscaling_group.name
 }
 
 output "cluster_tag_key" {
-  value = "${var.cluster_tag_key}"
+  value = var.cluster_tag_key
 }
 
 output "cluster_tag_value" {
-  value = "${var.cluster_tag_value}"
+  value = var.cluster_tag_value
 }
 
 output "cluster_size" {
-  value = "${aws_autoscaling_group.autoscaling_group.desired_capacity}"
+  value = aws_autoscaling_group.autoscaling_group.desired_capacity
 }
 
 output "launch_config_name" {
-  value = "${aws_launch_configuration.launch_configuration.name}"
+  value = aws_launch_configuration.launch_configuration.name
 }
 
 output "iam_role_arn" {
-  value = "${aws_iam_role.instance_role.arn}"
+  value = aws_iam_role.instance_role.arn
 }
 
 output "iam_role_id" {
-  value = "${aws_iam_role.instance_role.id}"
+  value = aws_iam_role.instance_role.id
 }
 
 output "security_group_id" {
-  value = "${aws_security_group.lc_security_group.id}"
+  value = aws_security_group.lc_security_group.id
 }
+

--- a/modules/nomad-cluster/variables.tf
+++ b/modules/nomad-cluster/variables.tf
@@ -193,8 +193,13 @@ variable "security_groups" {
 
 variable "tags" {
   description = "List of extra tag blocks added to the autoscaling group configuration. Each element in the list is a map containing keys 'key', 'value', and 'propagate_at_launch' mapped to the respective values."
-  type        = list(object({ key : string, value : string, propagate_at_launch : bool }))
-  default     = []
+  type = list(object({
+    key                 = string
+    value               = string
+    propagate_at_launch = bool
+  }))
+  default = []
+  
 }
 
 variable "ebs_block_devices" {

--- a/modules/nomad-cluster/variables.tf
+++ b/modules/nomad-cluster/variables.tf
@@ -5,22 +5,22 @@
 
 variable "cluster_name" {
   description = "The name of the Nomad cluster (e.g. nomad-servers-stage). This variable is used to namespace all resources created by this module."
-  type=string
+  type        = string
 }
 
 variable "ami_id" {
   description = "The ID of the AMI to run in this cluster. Should be an AMI that had Nomad installed and configured by the install-nomad module."
-  type=string
+  type        = string
 }
 
 variable "instance_type" {
   description = "The type of EC2 Instances to run for each node in the cluster (e.g. t2.micro)."
-  type=string
+  type        = string
 }
 
 variable "vpc_id" {
   description = "The ID of the VPC in which to deploy the cluster"
-  type=string
+  type        = string
 }
 
 variable "allowed_inbound_cidr_blocks" {
@@ -30,22 +30,22 @@ variable "allowed_inbound_cidr_blocks" {
 
 variable "user_data" {
   description = "A User Data script to execute while the server is booting. We remmend passing in a bash script that executes the run-nomad script, which should have been installed in the AMI by the install-nomad module."
-  type=string
+  type        = string
 }
 
 variable "min_size" {
   description = "The minimum number of nodes to have in the cluster. If you're using this to run Nomad servers, we strongly recommend setting this to 3 or 5."
-  type=number
+  type        = number
 }
 
 variable "max_size" {
   description = "The maximum number of nodes to have in the cluster. If you're using this to run Nomad servers, we strongly recommend setting this to 3 or 5."
-  type=number
+  type        = number
 }
 
 variable "desired_capacity" {
   description = "The desired number of nodes to have in the cluster. If you're using this to run Nomad servers, we strongly recommend setting this to 3 or 5."
-  type=number
+  type        = number
 }
 
 # ---------------------------------------------------------------------------------------------------------------------
@@ -55,7 +55,7 @@ variable "desired_capacity" {
 
 variable "asg_name" {
   description = "The name to use for the Auto Scaling Group"
-  type=string
+  type        = string
   default     = ""
 }
 
@@ -73,7 +73,7 @@ variable "availability_zones" {
 
 variable "ssh_key_name" {
   description = "The name of an EC2 Key Pair that can be used to SSH to the EC2 Instances in this cluster. Set to an empty string to not associate a Key Pair."
-  type=string
+  type        = string
   default     = ""
 }
 
@@ -85,103 +85,103 @@ variable "allowed_ssh_cidr_blocks" {
 
 variable "cluster_tag_key" {
   description = "Add a tag with this key and the value var.cluster_tag_value to each Instance in the ASG."
-  type=string
+  type        = string
   default     = "nomad-servers"
 }
 
 variable "cluster_tag_value" {
   description = "Add a tag with key var.cluster_tag_key and this value to each Instance in the ASG. This can be used to automatically find other Consul nodes and form a cluster."
-  type=string
+  type        = string
   default     = "auto-join"
 }
 
 variable "termination_policies" {
   description = "A list of policies to decide how the instances in the auto scale group should be terminated. The allowed values are OldestInstance, NewestInstance, OldestLaunchConfiguration, ClosestToNextInstanceHour, Default."
-  type=string
+  type        = string
   default     = "Default"
 }
 
 variable "associate_public_ip_address" {
   description = "If set to true, associate a public IP address with each EC2 Instance in the cluster."
-  type=bool
+  type        = bool
   default     = false
 }
 
 variable "tenancy" {
   description = "The tenancy of the instance. Must be one of: default or dedicated."
-  type=string
+  type        = string
   default     = "default"
 }
 
 variable "root_volume_ebs_optimized" {
   description = "If true, the launched EC2 instance will be EBS-optimized."
-  type=bool
+  type        = bool
   default     = false
 }
 
 variable "root_volume_type" {
   description = "The type of volume. Must be one of: standard, gp2, or io1."
-  type=string
+  type        = string
   default     = "standard"
 }
 
 variable "root_volume_size" {
   description = "The size, in GB, of the root EBS volume."
-  type=number
+  type        = number
   default     = 50
 }
 
 variable "root_volume_delete_on_termination" {
   description = "Whether the volume should be destroyed on instance termination."
   default     = true
-  type=bool
+  type        = bool
 }
 
 variable "wait_for_capacity_timeout" {
   description = "A maximum duration that Terraform should wait for ASG instances to be healthy before timing out. Setting this to '0' causes Terraform to skip all Capacity Waiting behavior."
-  type=string
+  type        = string
   default     = "10m"
 }
 
 variable "health_check_type" {
   description = "Controls how health checking is done. Must be one of EC2 or ELB."
-  type=string
+  type        = string
   default     = "EC2"
 }
 
 variable "health_check_grace_period" {
   description = "Time, in seconds, after instance comes into service before checking health."
-  type=number
+  type        = number
   default     = 300
 }
 
 variable "instance_profile_path" {
   description = "Path in which to create the IAM instance profile."
-  type=string
+  type        = string
   default     = "/"
 }
 
 variable "http_port" {
   description = "The port to use for HTTP"
-  type=number
+  type        = number
   default     = 4646
 }
 
 variable "rpc_port" {
   description = "The port to use for RPC"
-  type=number
+  type        = number
   default     = 4647
 }
 
 variable "serf_port" {
   description = "The port to use for Serf"
-  type=number
+  type        = number
   default     = 4648
 }
 
 variable "ssh_port" {
   description = "The port used for SSH connections"
-  type=number
+  type        = number
   default     = 22
 }
 
@@ -204,7 +204,7 @@ variable "ebs_block_devices" {
   # the values in the map must be of the same type, whereas we need some to be strings, some to be bools, and some to
   # be ints. So, we have to fall back to just any ugly "any."
   type    = any
-  default     = []
+  default = []
   # Example:
   #
   # default = [

--- a/modules/nomad-cluster/variables.tf
+++ b/modules/nomad-cluster/variables.tf
@@ -5,39 +5,47 @@
 
 variable "cluster_name" {
   description = "The name of the Nomad cluster (e.g. nomad-servers-stage). This variable is used to namespace all resources created by this module."
+  type=string
 }
 
 variable "ami_id" {
   description = "The ID of the AMI to run in this cluster. Should be an AMI that had Nomad installed and configured by the install-nomad module."
+  type=string
 }
 
 variable "instance_type" {
   description = "The type of EC2 Instances to run for each node in the cluster (e.g. t2.micro)."
+  type=string
 }
 
 variable "vpc_id" {
   description = "The ID of the VPC in which to deploy the cluster"
+  type=string
 }
 
 variable "allowed_inbound_cidr_blocks" {
   description = "A list of CIDR-formatted IP address ranges from which the EC2 Instances will allow connections to Nomad"
-  type        = "list"
+  type        = list(string)
 }
 
 variable "user_data" {
   description = "A User Data script to execute while the server is booting. We remmend passing in a bash script that executes the run-nomad script, which should have been installed in the AMI by the install-nomad module."
+  type=string
 }
 
 variable "min_size" {
   description = "The minimum number of nodes to have in the cluster. If you're using this to run Nomad servers, we strongly recommend setting this to 3 or 5."
+  type=number
 }
 
 variable "max_size" {
   description = "The maximum number of nodes to have in the cluster. If you're using this to run Nomad servers, we strongly recommend setting this to 3 or 5."
+  type=number
 }
 
 variable "desired_capacity" {
   description = "The desired number of nodes to have in the cluster. If you're using this to run Nomad servers, we strongly recommend setting this to 3 or 5."
+  type=number
 }
 
 # ---------------------------------------------------------------------------------------------------------------------
@@ -47,140 +55,165 @@ variable "desired_capacity" {
 
 variable "asg_name" {
   description = "The name to use for the Auto Scaling Group"
+  type=string
   default     = ""
 }
 
 variable "subnet_ids" {
   description = "The subnet IDs into which the EC2 Instances should be deployed. We recommend one subnet ID per node in the cluster_size variable. At least one of var.subnet_ids or var.availability_zones must be non-empty."
-  type        = "list"
+  type        = list(string)
   default     = []
 }
 
 variable "availability_zones" {
   description = "The availability zones into which the EC2 Instances should be deployed. We recommend one availability zone per node in the cluster_size variable. At least one of var.subnet_ids or var.availability_zones must be non-empty."
-  type        = "list"
+  type        = list(string)
   default     = []
 }
 
 variable "ssh_key_name" {
   description = "The name of an EC2 Key Pair that can be used to SSH to the EC2 Instances in this cluster. Set to an empty string to not associate a Key Pair."
+  type=string
   default     = ""
 }
 
 variable "allowed_ssh_cidr_blocks" {
   description = "A list of CIDR-formatted IP address ranges from which the EC2 Instances will allow SSH connections"
-  type        = "list"
+  type        = list(string)
   default     = []
 }
 
 variable "cluster_tag_key" {
   description = "Add a tag with this key and the value var.cluster_tag_value to each Instance in the ASG."
+  type=string
   default     = "nomad-servers"
 }
 
 variable "cluster_tag_value" {
   description = "Add a tag with key var.cluster_tag_key and this value to each Instance in the ASG. This can be used to automatically find other Consul nodes and form a cluster."
+  type=string
   default     = "auto-join"
 }
 
 variable "termination_policies" {
   description = "A list of policies to decide how the instances in the auto scale group should be terminated. The allowed values are OldestInstance, NewestInstance, OldestLaunchConfiguration, ClosestToNextInstanceHour, Default."
+  type=string
   default     = "Default"
 }
 
 variable "associate_public_ip_address" {
   description = "If set to true, associate a public IP address with each EC2 Instance in the cluster."
+  type=bool
   default     = false
 }
 
 variable "tenancy" {
   description = "The tenancy of the instance. Must be one of: default or dedicated."
+  type=string
   default     = "default"
 }
 
 variable "root_volume_ebs_optimized" {
   description = "If true, the launched EC2 instance will be EBS-optimized."
+  type=bool
   default     = false
 }
 
 variable "root_volume_type" {
   description = "The type of volume. Must be one of: standard, gp2, or io1."
+  type=string
   default     = "standard"
 }
 
 variable "root_volume_size" {
   description = "The size, in GB, of the root EBS volume."
+  type=number
   default     = 50
 }
 
 variable "root_volume_delete_on_termination" {
   description = "Whether the volume should be destroyed on instance termination."
   default     = true
+  type=bool
 }
 
 variable "wait_for_capacity_timeout" {
   description = "A maximum duration that Terraform should wait for ASG instances to be healthy before timing out. Setting this to '0' causes Terraform to skip all Capacity Waiting behavior."
+  type=string
   default     = "10m"
 }
 
 variable "health_check_type" {
   description = "Controls how health checking is done. Must be one of EC2 or ELB."
+  type=string
   default     = "EC2"
 }
 
 variable "health_check_grace_period" {
   description = "Time, in seconds, after instance comes into service before checking health."
+  type=number
   default     = 300
 }
 
 variable "instance_profile_path" {
   description = "Path in which to create the IAM instance profile."
+  type=string
   default     = "/"
 }
 
 variable "http_port" {
   description = "The port to use for HTTP"
+  type=number
   default     = 4646
 }
 
 variable "rpc_port" {
   description = "The port to use for RPC"
+  type=number
   default     = 4647
 }
 
 variable "serf_port" {
   description = "The port to use for Serf"
+  type=number
   default     = 4648
 }
 
 variable "ssh_port" {
   description = "The port used for SSH connections"
+  type=number
   default     = 22
 }
 
 variable "security_groups" {
   description = "Additional security groups to attach to the EC2 instances"
-  type        = "list"
+  type        = list(string)
   default     = []
 }
 
 variable "tags" {
   description = "List of extra tag blocks added to the autoscaling group configuration. Each element in the list is a map containing keys 'key', 'value', and 'propagate_at_launch' mapped to the respective values."
-  type        = "list"
+  type        = list(object({ key : string, value : string, propagate_at_launch : bool }))
   default     = []
 }
 
-# Example for a ebs_block_device created from a snapshot and one with a certain size.
-# ebs_block_devices = [{
-#    "device_name" = "/dev/xvdf"
-#    "snapshot_id" = "snap-XYZ"
-#  },
-#  {
-#    "device_name" = "/dev/xvde"
-#    "volume_size" = "50"
-#  }]
 variable "ebs_block_devices" {
   description = "List of ebs volume definitions for those ebs_volumes that should be added to the instances created with the EC2 launch-configuration. Each element in the list is a map containing keys defined for ebs_block_device (see: https://www.terraform.io/docs/providers/aws/r/launch_configuration.html#ebs_block_device."
-  type        = "list"
+  # We can't narrow the type down more than "any" because if we use list(object(...)), then all the fields in the
+  # object will be required (whereas some, such as encrypted, should be optional), and if we use list(map(...)), all
+  # the values in the map must be of the same type, whereas we need some to be strings, some to be bools, and some to
+  # be ints. So, we have to fall back to just any ugly "any."
+  type    = any
   default     = []
+  # Example:
+  #
+  # default = [
+  #   {
+  #     device_name = "/dev/xvdh"
+  #     volume_type = "gp2"
+  #     volume_size = 300
+  #     encrypted   = true
+  #   }
+  # ]
 }
+

--- a/modules/nomad-security-group-rules/README.md
+++ b/modules/nomad-security-group-rules/README.md
@@ -25,7 +25,7 @@ servers have the necessary ports open for using Nomad, you can use this module a
 module "security_group_rules" {
   source = "github.com/hashicorp/terraform-aws-nomad//modules/nomad-security-group-rules?ref=v0.0.1"
 
-  security_group_id = "${module.consul_servers.security_group_id}"
+  security_group_id = module.consul_servers.security_group_id
 
   # ... (other params omitted) ...
 }

--- a/modules/nomad-security-group-rules/README.md
+++ b/modules/nomad-security-group-rules/README.md
@@ -1,48 +1,47 @@
 # Nomad Security Group Rules Module
 
-This folder contains a [Terraform](https://www.terraform.io/) module that defines the security group rules used by a 
-[Nomad](https://www.nomadproject.io/) cluster to control the traffic that is allowed to go in and out of the cluster. 
+This folder contains a [Terraform](https://www.terraform.io/) module that defines the security group rules used by a
+[Nomad](https://www.nomadproject.io/) cluster to control the traffic that is allowed to go in and out of the cluster.
 
-Normally, you'd get these rules by default if you're using the [nomad-cluster module](https://github.com/hashicorp/terraform-aws-nomad/tree/master/examples/nomad-cluster), but if 
-you're running Nomad on top of a different cluster, then you can use this module to add the necessary security group 
-rules that that cluster. For example, imagine you were using the [consul-cluster 
-module](https://github.com/hashicorp/terraform-aws-consul/tree/master/modules/consul-cluster) to run a cluster of 
+Normally, you'd get these rules by default if you're using the [nomad-cluster module](https://github.com/hashicorp/terraform-aws-nomad/tree/master/examples/nomad-cluster), but if
+you're running Nomad on top of a different cluster, then you can use this module to add the necessary security group
+rules that that cluster. For example, imagine you were using the [consul-cluster
+module](https://github.com/hashicorp/terraform-aws-consul/tree/master/modules/consul-cluster) to run a cluster of
 servers that have both Nomad and Consul on each node:
 
 ```hcl
 module "consul_servers" {
-  source = "github.com/hashicorp/terraform-aws-consul//modules/consul-cluster?ref=v0.3.1"
-  
+  source = "github.com/hashicorp/terraform-aws-consul//modules/consul-cluster?ref=v0.7.0"
+
   # This AMI has both Nomad and Consul installed
   ami_id = "ami-1234abcd"
 }
 ```
 
-The `consul-cluster` module will provide the security group rules for Consul, but not for Nomad. To ensure those 
+The `consul-cluster` module will provide the security group rules for Consul, but not for Nomad. To ensure those
 servers have the necessary ports open for using Nomad, you can use this module as follows:
-
 
 ```hcl
 module "security_group_rules" {
   source = "github.com/hashicorp/terraform-aws-nomad//modules/nomad-security-group-rules?ref=v0.0.1"
 
   security_group_id = "${module.consul_servers.security_group_id}"
-  
+
   # ... (other params omitted) ...
 }
 ```
 
 Note the following parameters:
 
-* `source`: Use this parameter to specify the URL of this module. The double slash (`//`) is intentional 
-  and required. Terraform uses it to specify subfolders within a Git repo (see [module 
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in 
-  this repo. That way, instead of using the latest version of this module from the `master` branch, which 
+- `source`: Use this parameter to specify the URL of this module. The double slash (`//`) is intentional
+  and required. Terraform uses it to specify subfolders within a Git repo (see [module
+  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  this repo. That way, instead of using the latest version of this module from the `master` branch, which
   will change every time you run Terraform, you're using a fixed version of the repo.
 
-* `security_group_id`: Use this parameter to specify the ID of the security group to which the rules in this module
+- `security_group_id`: Use this parameter to specify the ID of the security group to which the rules in this module
   should be added.
-  
+
 You can find the other parameters in [vars.tf](vars.tf).
 
 Check out the [nomad-consul-colocated-cluster example](https://github.com/hashicorp/terraform-aws-nomad/tree/master/MAIN.md) for working

--- a/modules/nomad-security-group-rules/main.tf
+++ b/modules/nomad-security-group-rules/main.tf
@@ -2,42 +2,51 @@
 # CREATE THE SECURITY GROUP RULES THAT CONTROL WHAT TRAFFIC CAN GO IN AND OUT OF A NOMAD CLUSTER
 # ---------------------------------------------------------------------------------------------------------------------
 
+# ----------------------------------------------------------------------------------------------------------------------
+# REQUIRE A SPECIFIC TERRAFORM VERSION OR HIGHER
+# This module has been updated with 0.12 syntax, which means it is no longer compatible with any versions below 0.12.
+# ----------------------------------------------------------------------------------------------------------------------
+terraform {
+  required_version = ">= 0.12"
+}
+
 resource "aws_security_group_rule" "allow_http_inbound" {
   type        = "ingress"
-  from_port   = "${var.http_port}"
-  to_port     = "${var.http_port}"
+  from_port   = var.http_port
+  to_port     = var.http_port
   protocol    = "tcp"
-  cidr_blocks = ["${var.allowed_inbound_cidr_blocks}"]
+  cidr_blocks = var.allowed_inbound_cidr_blocks
 
-  security_group_id = "${var.security_group_id}"
+  security_group_id = var.security_group_id
 }
 
 resource "aws_security_group_rule" "allow_rpc_inbound" {
   type        = "ingress"
-  from_port   = "${var.rpc_port}"
-  to_port     = "${var.rpc_port}"
+  from_port   = var.rpc_port
+  to_port     = var.rpc_port
   protocol    = "tcp"
-  cidr_blocks = ["${var.allowed_inbound_cidr_blocks}"]
+  cidr_blocks = var.allowed_inbound_cidr_blocks
 
-  security_group_id = "${var.security_group_id}"
+  security_group_id = var.security_group_id
 }
 
 resource "aws_security_group_rule" "allow_serf_tcp_inbound" {
   type        = "ingress"
-  from_port   = "${var.serf_port}"
-  to_port     = "${var.serf_port}"
+  from_port   = var.serf_port
+  to_port     = var.serf_port
   protocol    = "tcp"
-  cidr_blocks = ["${var.allowed_inbound_cidr_blocks}"]
+  cidr_blocks = var.allowed_inbound_cidr_blocks
 
-  security_group_id = "${var.security_group_id}"
+  security_group_id = var.security_group_id
 }
 
 resource "aws_security_group_rule" "allow_serf_udp_inbound" {
   type        = "ingress"
-  from_port   = "${var.serf_port}"
-  to_port     = "${var.serf_port}"
+  from_port   = var.serf_port
+  to_port     = var.serf_port
   protocol    = "udp"
-  cidr_blocks = ["${var.allowed_inbound_cidr_blocks}"]
+  cidr_blocks = var.allowed_inbound_cidr_blocks
 
-  security_group_id = "${var.security_group_id}"
+  security_group_id = var.security_group_id
 }
+

--- a/modules/nomad-security-group-rules/variables.tf
+++ b/modules/nomad-security-group-rules/variables.tf
@@ -5,7 +5,7 @@
 
 variable "security_group_id" {
   description = "The ID of the security group to which we should add the Nomad security group rules"
-  type=string
+  type        = string
 }
 
 variable "allowed_inbound_cidr_blocks" {
@@ -20,19 +20,19 @@ variable "allowed_inbound_cidr_blocks" {
 
 variable "http_port" {
   description = "The port to use for HTTP"
-  type=number
+  type        = number
   default     = 4646
 }
 
 variable "rpc_port" {
   description = "The port to use for RPC"
-  type=number
+  type        = number
   default     = 4647
 }
 
 variable "serf_port" {
   description = "The port to use for Serf"
-  type=number
+  type        = number
   default     = 4648
 }
 

--- a/modules/nomad-security-group-rules/variables.tf
+++ b/modules/nomad-security-group-rules/variables.tf
@@ -5,11 +5,12 @@
 
 variable "security_group_id" {
   description = "The ID of the security group to which we should add the Nomad security group rules"
+  type=string
 }
 
 variable "allowed_inbound_cidr_blocks" {
   description = "A list of CIDR-formatted IP address ranges from which the EC2 Instances will allow connections to Nomad"
-  type        = "list"
+  type        = list(string)
 }
 
 # ---------------------------------------------------------------------------------------------------------------------
@@ -19,15 +20,19 @@ variable "allowed_inbound_cidr_blocks" {
 
 variable "http_port" {
   description = "The port to use for HTTP"
+  type=number
   default     = 4646
 }
 
 variable "rpc_port" {
   description = "The port to use for RPC"
+  type=number
   default     = 4647
 }
 
 variable "serf_port" {
   description = "The port to use for Serf"
+  type=number
   default     = 4648
 }
+

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,59 +1,60 @@
 output "num_nomad_servers" {
-  value = "${module.servers.cluster_size}"
+  value = module.servers.cluster_size
 }
 
 output "asg_name_servers" {
-  value = "${module.servers.asg_name}"
+  value = module.servers.asg_name
 }
 
 output "launch_config_name_servers" {
-  value = "${module.servers.launch_config_name}"
+  value = module.servers.launch_config_name
 }
 
 output "iam_role_arn_servers" {
-  value = "${module.servers.iam_role_arn}"
+  value = module.servers.iam_role_arn
 }
 
 output "iam_role_id_servers" {
-  value = "${module.servers.iam_role_id}"
+  value = module.servers.iam_role_id
 }
 
 output "security_group_id_servers" {
-  value = "${module.servers.security_group_id}"
+  value = module.servers.security_group_id
 }
 
 output "num_clients" {
-  value = "${module.clients.cluster_size}"
+  value = module.clients.cluster_size
 }
 
 output "asg_name_clients" {
-  value = "${module.clients.asg_name}"
+  value = module.clients.asg_name
 }
 
 output "launch_config_name_clients" {
-  value = "${module.clients.launch_config_name}"
+  value = module.clients.launch_config_name
 }
 
 output "iam_role_arn_clients" {
-  value = "${module.clients.iam_role_arn}"
+  value = module.clients.iam_role_arn
 }
 
 output "iam_role_id_clients" {
-  value = "${module.clients.iam_role_id}"
+  value = module.clients.iam_role_id
 }
 
 output "security_group_id_clients" {
-  value = "${module.clients.security_group_id}"
+  value = module.clients.security_group_id
 }
 
 output "aws_region" {
-  value = "${data.aws_region.current.name}"
+  value = data.aws_region.current.name
 }
 
 output "nomad_servers_cluster_tag_key" {
-  value = "${module.servers.cluster_tag_key}"
+  value = module.servers.cluster_tag_key
 }
 
 output "nomad_servers_cluster_tag_value" {
-  value = "${module.servers.cluster_tag_value}"
+  value = module.servers.cluster_tag_value
 }
+

--- a/test/Gopkg.lock
+++ b/test/Gopkg.lock
@@ -2,61 +2,668 @@
 
 
 [[projects]]
-  name = "github.com/aws/aws-sdk-go"
-  packages = ["aws","aws/awserr","aws/awsutil","aws/client","aws/client/metadata","aws/corehandlers","aws/credentials","aws/credentials/ec2rolecreds","aws/credentials/endpointcreds","aws/credentials/stscreds","aws/defaults","aws/ec2metadata","aws/endpoints","aws/request","aws/session","aws/signer/v4","internal/sdkio","internal/sdkrand","internal/shareddefaults","private/protocol","private/protocol/ec2query","private/protocol/json/jsonutil","private/protocol/jsonrpc","private/protocol/query","private/protocol/query/queryutil","private/protocol/rest","private/protocol/restxml","private/protocol/xml/xmlutil","service/acm","service/autoscaling","service/cloudwatchlogs","service/ec2","service/iam","service/kms","service/s3","service/sns","service/sqs","service/sts"]
-  revision = "cb873de7862ba08c63e82f37ffebc5ba02d87d26"
-  version = "v1.13.38"
+  digest = "1:1a37f9f2ae10d161d9688fb6008ffa14e1631e5068cc3e9698008b9e8d40d575"
+  name = "cloud.google.com/go"
+  packages = ["compute/metadata"]
+  pruneopts = ""
+  revision = "457ea5c15ccf3b87db582c450e80101989da35f7"
+  version = "v0.40.0"
 
 [[projects]]
+  digest = "1:5ec1dc66c936679b8e7c9f8ee3a723fed6c7d8a65b278452a382ab266c65e8b7"
+  name = "github.com/aws/aws-sdk-go"
+  packages = [
+    "aws",
+    "aws/awserr",
+    "aws/awsutil",
+    "aws/client",
+    "aws/client/metadata",
+    "aws/corehandlers",
+    "aws/credentials",
+    "aws/credentials/ec2rolecreds",
+    "aws/credentials/endpointcreds",
+    "aws/credentials/processcreds",
+    "aws/credentials/stscreds",
+    "aws/crr",
+    "aws/csm",
+    "aws/defaults",
+    "aws/ec2metadata",
+    "aws/endpoints",
+    "aws/request",
+    "aws/session",
+    "aws/signer/v4",
+    "internal/ini",
+    "internal/s3err",
+    "internal/sdkio",
+    "internal/sdkrand",
+    "internal/sdkuri",
+    "internal/shareddefaults",
+    "private/protocol",
+    "private/protocol/ec2query",
+    "private/protocol/eventstream",
+    "private/protocol/eventstream/eventstreamapi",
+    "private/protocol/json/jsonutil",
+    "private/protocol/jsonrpc",
+    "private/protocol/query",
+    "private/protocol/query/queryutil",
+    "private/protocol/rest",
+    "private/protocol/restxml",
+    "private/protocol/xml/xmlutil",
+    "service/acm",
+    "service/autoscaling",
+    "service/cloudwatchlogs",
+    "service/dynamodb",
+    "service/ec2",
+    "service/ecs",
+    "service/iam",
+    "service/kms",
+    "service/rds",
+    "service/s3",
+    "service/s3/s3iface",
+    "service/s3/s3manager",
+    "service/sns",
+    "service/sqs",
+    "service/ssm",
+    "service/sts",
+  ]
+  pruneopts = ""
+  revision = "ef92c4e80137a128273036d32ba8bc6596085250"
+  version = "v1.20.9"
+
+[[projects]]
+  digest = "1:b529f4bf748979caa18b599d40d13e8b6e591a74b340f315ce4f95e119c288c2"
   name = "github.com/boombuler/barcode"
-  packages = [".","qr","utils"]
+  packages = [
+    ".",
+    "qr",
+    "utils",
+  ]
+  pruneopts = ""
   revision = "3cfea5ab600ae37946be2b763b8ec2c1cf2d272d"
   version = "v1.0.0"
 
 [[projects]]
-  name = "github.com/go-ini/ini"
+  digest = "1:0deddd908b6b4b768cfc272c16ee61e7088a60f7fe2f06c547bd3d8e1f8b8e77"
+  name = "github.com/davecgh/go-spew"
+  packages = ["spew"]
+  pruneopts = ""
+  revision = "8991bc29aa16c548c550c7ff78260e27b9ab7c73"
+  version = "v1.1.1"
+
+[[projects]]
+  branch = "master"
+  digest = "1:d6c13a378213e3de60445e49084b8a0a9ce582776dfc77927775dbeb3ff72a35"
+  name = "github.com/docker/spdystream"
+  packages = [
+    ".",
+    "spdy",
+  ]
+  pruneopts = ""
+  revision = "6480d4af844c189cf5dd913db24ddd339d3a4f85"
+
+[[projects]]
+  digest = "1:b13707423743d41665fd23f0c36b2f37bb49c30e94adb813319c44188a51ba22"
+  name = "github.com/ghodss/yaml"
   packages = ["."]
-  revision = "6529cf7c58879c08d927016dde4477f18a0634cb"
-  version = "v1.36.0"
-
-[[projects]]
-  name = "github.com/google/uuid"
-  packages = ["."]
-  revision = "064e2069ce9c359c118179501254f67d7d37ba24"
-  version = "0.2"
-
-[[projects]]
-  name = "github.com/gruntwork-io/terratest"
-  packages = ["modules/aws","modules/collections","modules/files","modules/logger","modules/packer","modules/random","modules/retry","modules/shell","modules/ssh","modules/terraform","modules/test-structure"]
-  revision = "baaee143a328ab0fe3a78a0ebc80bb0f707ef8fc"
-  version = "v0.9.2"
-
-[[projects]]
-  name = "github.com/jmespath/go-jmespath"
-  packages = ["."]
-  revision = "0b12d6b5"
-
-[[projects]]
-  name = "github.com/pquerna/otp"
-  packages = [".","hotp","totp"]
-  revision = "b7b89250c468c06871d3837bee02e2d5c155ae19"
+  pruneopts = ""
+  revision = "0ca9ea5df5451ffdf184b4428c902747c2c11cd7"
   version = "v1.0.0"
 
 [[projects]]
   branch = "master"
-  name = "golang.org/x/crypto"
-  packages = ["curve25519","ed25519","ed25519/internal/edwards25519","internal/chacha20","poly1305","ssh"]
-  revision = "b49d69b5da943f7ef3c9cf91c8777c1f78a0cc3c"
+  digest = "1:26317724ed32bcf2ef15454613d2a8fe9d670b12f073cfd20db3bcec54e069ab"
+  name = "github.com/go-errors/errors"
+  packages = ["."]
+  pruneopts = ""
+  revision = "d98b870cc4e05f1545532a80e9909be8216095b6"
+
+[[projects]]
+  digest = "1:e692d16fdfbddb94e9e4886aaf6c08bdbae5cb4ac80651445de9181b371c6e46"
+  name = "github.com/go-sql-driver/mysql"
+  packages = ["."]
+  pruneopts = ""
+  revision = "72cd26f257d44c1114970e19afddcd812016007e"
+  version = "v1.4.1"
+
+[[projects]]
+  digest = "1:fd53b471edb4c28c7d297f617f4da0d33402755f58d6301e7ca1197ef0a90937"
+  name = "github.com/gogo/protobuf"
+  packages = [
+    "proto",
+    "sortkeys",
+  ]
+  pruneopts = ""
+  revision = "ba06b47c162d49f2af050fb4c75bcbc86a159d5c"
+  version = "v1.2.1"
 
 [[projects]]
   branch = "master"
+  digest = "1:107b233e45174dbab5b1324201d092ea9448e58243ab9f039e4c0f332e121e3a"
+  name = "github.com/golang/glog"
+  packages = ["."]
+  pruneopts = ""
+  revision = "23def4e6c14b4da8ac2ed8007337bc5eb5007998"
+
+[[projects]]
+  digest = "1:529d738b7976c3848cae5cf3a8036440166835e389c1f617af701eeb12a0518d"
+  name = "github.com/golang/protobuf"
+  packages = [
+    "proto",
+    "ptypes",
+    "ptypes/any",
+    "ptypes/duration",
+    "ptypes/timestamp",
+  ]
+  pruneopts = ""
+  revision = "b5d812f8a3706043e23a9cd5babf2e5423744d30"
+  version = "v1.3.1"
+
+[[projects]]
+  digest = "1:1e5b1e14524ed08301977b7b8e10c719ed853cbf3f24ecb66fae783a46f207a6"
+  name = "github.com/google/btree"
+  packages = ["."]
+  pruneopts = ""
+  revision = "4030bb1f1f0c35b30ca7009e9ebd06849dd45306"
+  version = "v1.0.0"
+
+[[projects]]
+  digest = "1:8d4a577a9643f713c25a32151c0f26af7228b4b97a219b5ddb7fd38d16f6e673"
+  name = "github.com/google/gofuzz"
+  packages = ["."]
+  pruneopts = ""
+  revision = "f140a6486e521aad38f5917de355cbf147cc0496"
+  version = "v1.0.0"
+
+[[projects]]
+  digest = "1:c1d7e883c50a26ea34019320d8ae40fad86c9e5d56e63a1ba2cb618cef43e986"
+  name = "github.com/google/uuid"
+  packages = ["."]
+  pruneopts = ""
+  revision = "064e2069ce9c359c118179501254f67d7d37ba24"
+  version = "0.2"
+
+[[projects]]
+  digest = "1:5facc3828b6a56f9aec988433ea33fb4407a89460952ed75be5347cec07318c0"
+  name = "github.com/googleapis/gnostic"
+  packages = [
+    "OpenAPIv2",
+    "compiler",
+    "extensions",
+  ]
+  pruneopts = ""
+  revision = "e73c7ec21d36ddb0711cb36d1502d18363b5c2c9"
+  version = "v0.3.0"
+
+[[projects]]
+  branch = "master"
+  digest = "1:e1fd67b5695fb12f54f979606c5d650a5aa72ef242f8e71072bfd4f7b5a141a0"
+  name = "github.com/gregjones/httpcache"
+  packages = [
+    ".",
+    "diskcache",
+  ]
+  pruneopts = ""
+  revision = "901d90724c7919163f472a9812253fb26761123d"
+
+[[projects]]
+  digest = "1:f032ebac9a824af56f183e82817a79792738f3faef09b4feced2252df7b253e7"
+  name = "github.com/gruntwork-io/gruntwork-cli"
+  packages = ["errors"]
+  pruneopts = ""
+  revision = "6a2163138f3d10377f313428e7e367b0a6c0c1c9"
+  version = "v0.4.2"
+
+[[projects]]
+  digest = "1:f4aa63932320bc30b5a0895d451eba4749e08a7fc18ba096a4bf2afcaeae9b5e"
+  name = "github.com/gruntwork-io/terratest"
+  packages = [
+    "modules/aws",
+    "modules/collections",
+    "modules/customerrors",
+    "modules/environment",
+    "modules/files",
+    "modules/k8s",
+    "modules/logger",
+    "modules/packer",
+    "modules/random",
+    "modules/retry",
+    "modules/shell",
+    "modules/ssh",
+    "modules/terraform",
+    "modules/test-structure",
+  ]
+  pruneopts = ""
+  revision = "295736141a96daa369a972e1409622d702c8f40e"
+  version = "v0.17.4"
+
+[[projects]]
+  digest = "1:31bfd110d31505e9ffbc9478e31773bf05bf02adcaeb9b139af42684f9294c13"
+  name = "github.com/imdario/mergo"
+  packages = ["."]
+  pruneopts = ""
+  revision = "7c29201646fa3de8506f701213473dd407f19646"
+  version = "v0.3.7"
+
+[[projects]]
+  digest = "1:870d441fe217b8e689d7949fef6e43efbc787e50f200cb1e70dbca9204a1d6be"
+  name = "github.com/inconshreveable/mousetrap"
+  packages = ["."]
+  pruneopts = ""
+  revision = "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75"
+  version = "v1.0"
+
+[[projects]]
+  digest = "1:13fe471d0ed891e8544eddfeeb0471fd3c9f2015609a1c000aefdedf52a19d40"
+  name = "github.com/jmespath/go-jmespath"
+  packages = ["."]
+  pruneopts = ""
+  revision = "c2b33e84"
+
+[[projects]]
+  digest = "1:12d3de2c11e54ea37d7f00daf85088ad5e61ec4e8a1f828d6c8b657976856be7"
+  name = "github.com/json-iterator/go"
+  packages = ["."]
+  pruneopts = ""
+  revision = "0ff49de124c6f76f8494e194af75bde0f1a49a29"
+  version = "v1.1.6"
+
+[[projects]]
+  digest = "1:6dbb0eb72090871f2e58d1e37973fe3cb8c0f45f49459398d3fc740cb30e13bd"
+  name = "github.com/mitchellh/go-homedir"
+  packages = ["."]
+  pruneopts = ""
+  revision = "af06845cf3004701891bf4fdb884bfe4920b3727"
+  version = "v1.1.0"
+
+[[projects]]
+  digest = "1:0c0ff2a89c1bb0d01887e1dac043ad7efbf3ec77482ef058ac423d13497e16fd"
+  name = "github.com/modern-go/concurrent"
+  packages = ["."]
+  pruneopts = ""
+  revision = "bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94"
+  version = "1.0.3"
+
+[[projects]]
+  digest = "1:e32bdbdb7c377a07a9a46378290059822efdce5c8d96fe71940d87cb4f918855"
+  name = "github.com/modern-go/reflect2"
+  packages = ["."]
+  pruneopts = ""
+  revision = "4b7aa43c6742a2c18fdef89dd197aaae7dac7ccd"
+  version = "1.0.1"
+
+[[projects]]
+  branch = "master"
+  digest = "1:5f0faa008e8ff4221b55a1a5057c8b02cb2fd68da6a65c9e31c82b72cbc836d0"
+  name = "github.com/petar/GoLLRB"
+  packages = ["llrb"]
+  pruneopts = ""
+  revision = "33fb24c13b99c46c93183c291836c573ac382536"
+
+[[projects]]
+  digest = "1:4709c61d984ef9ba99b037b047546d8a576ae984fb49486e48d99658aa750cd5"
+  name = "github.com/peterbourgon/diskv"
+  packages = ["."]
+  pruneopts = ""
+  revision = "0be1b92a6df0e4f5cb0a5d15fb7f643d0ad93ce6"
+  version = "v3.0.0"
+
+[[projects]]
+  digest = "1:256484dbbcd271f9ecebc6795b2df8cad4c458dd0f5fd82a8c2fa0c29f233411"
+  name = "github.com/pmezard/go-difflib"
+  packages = ["difflib"]
+  pruneopts = ""
+  revision = "792786c7400a136282c1664665ae0a8db921c6c2"
+  version = "v1.0.0"
+
+[[projects]]
+  digest = "1:09d0eed1a0e502dfff8227c3fdbe022ea4bd722c1db3daf7251f20cfc549b428"
+  name = "github.com/pquerna/otp"
+  packages = [
+    ".",
+    "hotp",
+    "totp",
+  ]
+  pruneopts = ""
+  revision = "43bebefda392017900e7a7b237b4c914c6a55b50"
+  version = "v1.2.0"
+
+[[projects]]
+  digest = "1:0c63b3c7ad6d825a898f28cb854252a3b29d37700c68a117a977263f5ec94efe"
+  name = "github.com/spf13/cobra"
+  packages = ["."]
+  pruneopts = ""
+  revision = "f2b07da1e2c38d5f12845a4f607e2e1018cbb1f5"
+  version = "v0.0.5"
+
+[[projects]]
+  digest = "1:cbaf13cdbfef0e4734ed8a7504f57fe893d471d62a35b982bf6fb3f036449a66"
+  name = "github.com/spf13/pflag"
+  packages = ["."]
+  pruneopts = ""
+  revision = "298182f68c66c05229eb03ac171abe6e309ee79a"
+  version = "v1.0.3"
+
+[[projects]]
+  digest = "1:381bcbeb112a51493d9d998bbba207a529c73dbb49b3fd789e48c63fac1f192c"
+  name = "github.com/stretchr/testify"
+  packages = [
+    "assert",
+    "require",
+  ]
+  pruneopts = ""
+  revision = "ffdc059bfe9ce6a4e144ba849dbedead332c6053"
+  version = "v1.3.0"
+
+[[projects]]
+  digest = "1:e85837cb04b78f61688c6eba93ea9d14f60d611e2aaf8319999b1a60d2dafbfa"
+  name = "github.com/urfave/cli"
+  packages = ["."]
+  pruneopts = ""
+  revision = "cfb38830724cc34fedffe9a2a29fb54fa9169cd1"
+  version = "v1.20.0"
+
+[[projects]]
+  branch = "master"
+  digest = "1:90722da867436e04650b8491e5d9f690aeb2a4e305d548666bdd541d68d6cdbd"
+  name = "golang.org/x/crypto"
+  packages = [
+    "curve25519",
+    "ed25519",
+    "ed25519/internal/edwards25519",
+    "internal/chacha20",
+    "internal/subtle",
+    "poly1305",
+    "ssh",
+    "ssh/agent",
+    "ssh/terminal",
+  ]
+  pruneopts = ""
+  revision = "cc06ce4a13d484c0101a9e92913248488a75786d"
+
+[[projects]]
+  branch = "master"
+  digest = "1:5c6b8395efd72ad4250b7747e2b1a0683c3edb7b0346a938ff45240c7ec53691"
   name = "golang.org/x/net"
-  packages = ["context"]
-  revision = "5f9ae10d9af5b1c89ae6904293b14b064d4ada23"
+  packages = [
+    "context",
+    "context/ctxhttp",
+    "http/httpguts",
+    "http2",
+    "http2/hpack",
+    "idna",
+  ]
+  pruneopts = ""
+  revision = "3b0461eec859c4b73bb64fdc8285971fd33e3938"
+
+[[projects]]
+  branch = "master"
+  digest = "1:01bdbbc604dcd5afb6f66a717f69ad45e9643c72d5bc11678d44ffa5c50f9e42"
+  name = "golang.org/x/oauth2"
+  packages = [
+    ".",
+    "google",
+    "internal",
+    "jws",
+    "jwt",
+  ]
+  pruneopts = ""
+  revision = "0f29369cfe4552d0e4bcddc57cc75f4d7e672a33"
+
+[[projects]]
+  branch = "master"
+  digest = "1:6d5274ab605273eb179faa519615845f9e2e46ef93744db57570a60154e5b619"
+  name = "golang.org/x/sys"
+  packages = [
+    "cpu",
+    "unix",
+    "windows",
+  ]
+  pruneopts = ""
+  revision = "e07cf5db2756114766d998ec31e7135ff8c427ed"
+
+[[projects]]
+  digest = "1:740b51a55815493a8d0f2b1e0d0ae48fe48953bf7eaf3fcc4198823bf67768c0"
+  name = "golang.org/x/text"
+  packages = [
+    "collate",
+    "collate/build",
+    "internal/colltab",
+    "internal/gen",
+    "internal/language",
+    "internal/language/compact",
+    "internal/tag",
+    "internal/triegen",
+    "internal/ucd",
+    "language",
+    "secure/bidirule",
+    "transform",
+    "unicode/bidi",
+    "unicode/cldr",
+    "unicode/norm",
+    "unicode/rangetable",
+  ]
+  pruneopts = ""
+  revision = "342b2e1fbaa52c93f31447ad2c6abc048c63e475"
+  version = "v0.3.2"
+
+[[projects]]
+  branch = "master"
+  digest = "1:9522af4be529c108010f95b05f1022cb872f2b9ff8b101080f554245673466e1"
+  name = "golang.org/x/time"
+  packages = ["rate"]
+  pruneopts = ""
+  revision = "9d24e82272b4f38b78bc8cff74fa936d31ccd8ef"
+
+[[projects]]
+  digest = "1:47f391ee443f578f01168347818cb234ed819521e49e4d2c8dd2fb80d48ee41a"
+  name = "google.golang.org/appengine"
+  packages = [
+    ".",
+    "cloudsql",
+    "internal",
+    "internal/app_identity",
+    "internal/base",
+    "internal/datastore",
+    "internal/log",
+    "internal/modules",
+    "internal/remote_api",
+    "internal/urlfetch",
+    "urlfetch",
+  ]
+  pruneopts = ""
+  revision = "b2f4a3cf3c67576a2ee09e1fe62656a5086ce880"
+  version = "v1.6.1"
+
+[[projects]]
+  digest = "1:75fb3fcfc73a8c723efde7777b40e8e8ff9babf30d8c56160d01beffea8a95a6"
+  name = "gopkg.in/inf.v0"
+  packages = ["."]
+  pruneopts = ""
+  revision = "d2d2541c53f18d2a059457998ce2876cc8e67cbf"
+  version = "v0.9.1"
+
+[[projects]]
+  digest = "1:cedccf16b71e86db87a24f8d4c70b0a855872eb967cb906a66b95de56aefbd0d"
+  name = "gopkg.in/yaml.v2"
+  packages = ["."]
+  pruneopts = ""
+  revision = "51d6538a90f86fe93ac480b35f37b2be17fef232"
+  version = "v2.2.2"
+
+[[projects]]
+  branch = "release-1.12"
+  digest = "1:3e3e9df293bd6f9fd64effc9fa1f0edcd97e6c74145cd9ab05d35719004dc41f"
+  name = "k8s.io/api"
+  packages = [
+    "admissionregistration/v1alpha1",
+    "admissionregistration/v1beta1",
+    "apps/v1",
+    "apps/v1beta1",
+    "apps/v1beta2",
+    "authentication/v1",
+    "authentication/v1beta1",
+    "authorization/v1",
+    "authorization/v1beta1",
+    "autoscaling/v1",
+    "autoscaling/v2beta1",
+    "autoscaling/v2beta2",
+    "batch/v1",
+    "batch/v1beta1",
+    "batch/v2alpha1",
+    "certificates/v1beta1",
+    "coordination/v1beta1",
+    "core/v1",
+    "events/v1beta1",
+    "extensions/v1beta1",
+    "networking/v1",
+    "policy/v1beta1",
+    "rbac/v1",
+    "rbac/v1alpha1",
+    "rbac/v1beta1",
+    "scheduling/v1alpha1",
+    "scheduling/v1beta1",
+    "settings/v1alpha1",
+    "storage/v1",
+    "storage/v1alpha1",
+    "storage/v1beta1",
+  ]
+  pruneopts = ""
+  revision = "6db15a15d2d3874a6c3ddb2140ac9f3bc7058428"
+
+[[projects]]
+  branch = "release-1.12"
+  digest = "1:9c7ee6fe7b8b621df5a7604e9a1f752b566ae451b2cf010c9c075e5e5ff81f56"
+  name = "k8s.io/apimachinery"
+  packages = [
+    "pkg/api/errors",
+    "pkg/api/meta",
+    "pkg/api/resource",
+    "pkg/apis/meta/v1",
+    "pkg/apis/meta/v1/unstructured",
+    "pkg/apis/meta/v1beta1",
+    "pkg/conversion",
+    "pkg/conversion/queryparams",
+    "pkg/fields",
+    "pkg/labels",
+    "pkg/runtime",
+    "pkg/runtime/schema",
+    "pkg/runtime/serializer",
+    "pkg/runtime/serializer/json",
+    "pkg/runtime/serializer/protobuf",
+    "pkg/runtime/serializer/recognizer",
+    "pkg/runtime/serializer/streaming",
+    "pkg/runtime/serializer/versioning",
+    "pkg/selection",
+    "pkg/types",
+    "pkg/util/clock",
+    "pkg/util/errors",
+    "pkg/util/framer",
+    "pkg/util/httpstream",
+    "pkg/util/httpstream/spdy",
+    "pkg/util/intstr",
+    "pkg/util/json",
+    "pkg/util/naming",
+    "pkg/util/net",
+    "pkg/util/runtime",
+    "pkg/util/sets",
+    "pkg/util/validation",
+    "pkg/util/validation/field",
+    "pkg/util/yaml",
+    "pkg/version",
+    "pkg/watch",
+    "third_party/forked/golang/netutil",
+    "third_party/forked/golang/reflect",
+  ]
+  pruneopts = ""
+  revision = "01f179d85dbce0f2e0e4351a92394b38694b7cae"
+
+[[projects]]
+  branch = "release-9.0"
+  digest = "1:b1a32e8c431a032029c57bd211aa8b7e7de4fd7e142d4805be654da286f5efe4"
+  name = "k8s.io/client-go"
+  packages = [
+    "discovery",
+    "kubernetes",
+    "kubernetes/scheme",
+    "kubernetes/typed/admissionregistration/v1alpha1",
+    "kubernetes/typed/admissionregistration/v1beta1",
+    "kubernetes/typed/apps/v1",
+    "kubernetes/typed/apps/v1beta1",
+    "kubernetes/typed/apps/v1beta2",
+    "kubernetes/typed/authentication/v1",
+    "kubernetes/typed/authentication/v1beta1",
+    "kubernetes/typed/authorization/v1",
+    "kubernetes/typed/authorization/v1beta1",
+    "kubernetes/typed/autoscaling/v1",
+    "kubernetes/typed/autoscaling/v2beta1",
+    "kubernetes/typed/autoscaling/v2beta2",
+    "kubernetes/typed/batch/v1",
+    "kubernetes/typed/batch/v1beta1",
+    "kubernetes/typed/batch/v2alpha1",
+    "kubernetes/typed/certificates/v1beta1",
+    "kubernetes/typed/coordination/v1beta1",
+    "kubernetes/typed/core/v1",
+    "kubernetes/typed/events/v1beta1",
+    "kubernetes/typed/extensions/v1beta1",
+    "kubernetes/typed/networking/v1",
+    "kubernetes/typed/policy/v1beta1",
+    "kubernetes/typed/rbac/v1",
+    "kubernetes/typed/rbac/v1alpha1",
+    "kubernetes/typed/rbac/v1beta1",
+    "kubernetes/typed/scheduling/v1alpha1",
+    "kubernetes/typed/scheduling/v1beta1",
+    "kubernetes/typed/settings/v1alpha1",
+    "kubernetes/typed/storage/v1",
+    "kubernetes/typed/storage/v1alpha1",
+    "kubernetes/typed/storage/v1beta1",
+    "pkg/apis/clientauthentication",
+    "pkg/apis/clientauthentication/v1alpha1",
+    "pkg/apis/clientauthentication/v1beta1",
+    "pkg/version",
+    "plugin/pkg/client/auth/exec",
+    "plugin/pkg/client/auth/gcp",
+    "rest",
+    "rest/watch",
+    "third_party/forked/golang/template",
+    "tools/auth",
+    "tools/clientcmd",
+    "tools/clientcmd/api",
+    "tools/clientcmd/api/latest",
+    "tools/clientcmd/api/v1",
+    "tools/metrics",
+    "tools/portforward",
+    "tools/reference",
+    "transport",
+    "transport/spdy",
+    "util/cert",
+    "util/connrotation",
+    "util/flowcontrol",
+    "util/homedir",
+    "util/integer",
+    "util/jsonpath",
+  ]
+  pruneopts = ""
+  revision = "b6aa6aafe32b0767f075245e5d391381c5449c8a"
+
+[[projects]]
+  digest = "1:f27698f7ae7864893ebcfb843e44d821263ac1dcf0ba1d5c2353f9d319a2f28d"
+  name = "k8s.io/kubernetes"
+  packages = ["pkg/kubectl/generate"]
+  pruneopts = ""
+  revision = "e8462b5b5dc2584fdcd18e6bcfe9f1e4d970a529"
+  version = "v1.15.0"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "623e35a34630cf0e69d5f4394ba342a1d5c65b2b6c42aa34dd2bc0c644ed0c52"
+  input-imports = [
+    "github.com/gruntwork-io/terratest/modules/aws",
+    "github.com/gruntwork-io/terratest/modules/logger",
+    "github.com/gruntwork-io/terratest/modules/packer",
+    "github.com/gruntwork-io/terratest/modules/random",
+    "github.com/gruntwork-io/terratest/modules/retry",
+    "github.com/gruntwork-io/terratest/modules/terraform",
+    "github.com/gruntwork-io/terratest/modules/test-structure",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/test/Gopkg.toml
+++ b/test/Gopkg.toml
@@ -23,4 +23,4 @@
 
 [[constraint]]
   name = "github.com/gruntwork-io/terratest"
-  version = "0.9.2"
+  version = "0.17.4"

--- a/test/nomad_helpers.go
+++ b/test/nomad_helpers.go
@@ -109,7 +109,7 @@ func runNomadClusterColocatedTest(t *testing.T, packerBuildName string) {
 // 3. Deploying that AMI using the example Terraform code
 // 4. Checking that the Nomad cluster comes up within a reasonable time period and can respond to requests
 func runNomadClusterSeparateTest(t *testing.T, packerBuildName string) {
-	examplesDir := test_structure.CopyTerraformFolderToTemp(t, REPO_ROOT, CLUSTER_SEPARATE_EXAMPLE_PATH)
+	examplesDir := test_structure.CopyTerraformFolderToTemp(t, REPO_ROOT, "examples")
 
 	defer test_structure.RunTestStage(t, "teardown", func() {
 		terraformOptions := test_structure.LoadTerraformOptions(t, examplesDir)

--- a/test/nomad_helpers.go
+++ b/test/nomad_helpers.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gruntwork-io/terratest/modules/test-structure"
 	"io/ioutil"
 	"net/http"
+	"path/filepath"
 	"testing"
 	"time"
 )
@@ -50,7 +51,7 @@ const SAVED_AWS_REGION = "AwsRegion"
 // 3. Deploying that AMI using the example Terraform code
 // 4. Checking that the Nomad cluster comes up within a reasonable time period and can respond to requests
 func runNomadClusterColocatedTest(t *testing.T, packerBuildName string) {
-	examplesDir := test_structure.CopyTerraformFolderToTemp(t, REPO_ROOT, CLUSTER_COLOCATED_EXAMPLE_PATH)
+	examplesDir := test_structure.CopyTerraformFolderToTemp(t, REPO_ROOT, "examples")
 
 	defer test_structure.RunTestStage(t, "teardown", func() {
 		terraformOptions := test_structure.LoadTerraformOptions(t, examplesDir)
@@ -65,7 +66,8 @@ func runNomadClusterColocatedTest(t *testing.T, packerBuildName string) {
 		awsRegion := getRandomRegion(t)
 		test_structure.SaveString(t, examplesDir, SAVED_AWS_REGION, awsRegion)
 
-		amiId := buildAmi(t, AMI_EXAMPLE_PATH, packerBuildName, awsRegion)
+		packerTemplatePath := filepath.Join(examplesDir, "nomad-consul-ami", "nomad-consul.json")
+		amiId := buildAmi(t, packerTemplatePath, packerBuildName, awsRegion)
 		test_structure.SaveAmiId(t, examplesDir, amiId)
 	})
 
@@ -122,7 +124,8 @@ func runNomadClusterSeparateTest(t *testing.T, packerBuildName string) {
 		awsRegion := getRandomRegion(t)
 		test_structure.SaveString(t, examplesDir, SAVED_AWS_REGION, awsRegion)
 
-		amiId := buildAmi(t, AMI_EXAMPLE_PATH, packerBuildName, awsRegion)
+		packerTemplatePath := filepath.Join(examplesDir, "nomad-consul-ami", "nomad-consul.json")
+		amiId := buildAmi(t, packerTemplatePath, packerBuildName, awsRegion)
 		test_structure.SaveAmiId(t, examplesDir, amiId)
 	})
 

--- a/test/nomad_helpers.go
+++ b/test/nomad_helpers.go
@@ -39,7 +39,7 @@ const CLUSTER_SEPARATE_EXAMPLE_OUTPUT_NOMAD_SERVER_ASG_NAME = "asg_name_nomad_se
 const DEFAULT_NUM_SERVERS = 3
 const DEFAULT_NUM_CLIENTS = 6
 
-const AMI_EXAMPLE_PATH = "../examples/nomad-consul-ami/nomad-consul.json"
+// const AMI_EXAMPLE_PATH = "../examples/nomad-consul-ami/nomad-consul.json"
 
 const SAVED_AWS_REGION = "AwsRegion"
 
@@ -51,7 +51,7 @@ const SAVED_AWS_REGION = "AwsRegion"
 // 3. Deploying that AMI using the example Terraform code
 // 4. Checking that the Nomad cluster comes up within a reasonable time period and can respond to requests
 func runNomadClusterColocatedTest(t *testing.T, packerBuildName string) {
-	examplesDir := test_structure.CopyTerraformFolderToTemp(t, REPO_ROOT, "examples")
+	examplesDir := test_structure.CopyTerraformFolderToTemp(t, REPO_ROOT, CLUSTER_COLOCATED_EXAMPLE_PATH)
 
 	defer test_structure.RunTestStage(t, "teardown", func() {
 		terraformOptions := test_structure.LoadTerraformOptions(t, examplesDir)
@@ -66,8 +66,7 @@ func runNomadClusterColocatedTest(t *testing.T, packerBuildName string) {
 		awsRegion := getRandomRegion(t)
 		test_structure.SaveString(t, examplesDir, SAVED_AWS_REGION, awsRegion)
 
-		packerTemplatePath := filepath.Join(examplesDir, "nomad-consul-ami", "nomad-consul.json")
-		amiId := buildAmi(t, packerTemplatePath, packerBuildName, awsRegion)
+		amiId := buildAmi(t, filepath.Join(examplesDir, "examples", "nomad-consul-ami", "nomad-consul.json"), packerBuildName, awsRegion)
 		test_structure.SaveAmiId(t, examplesDir, amiId)
 	})
 
@@ -109,7 +108,7 @@ func runNomadClusterColocatedTest(t *testing.T, packerBuildName string) {
 // 3. Deploying that AMI using the example Terraform code
 // 4. Checking that the Nomad cluster comes up within a reasonable time period and can respond to requests
 func runNomadClusterSeparateTest(t *testing.T, packerBuildName string) {
-	examplesDir := test_structure.CopyTerraformFolderToTemp(t, REPO_ROOT, "examples")
+	examplesDir := test_structure.CopyTerraformFolderToTemp(t, REPO_ROOT, "/")
 
 	defer test_structure.RunTestStage(t, "teardown", func() {
 		terraformOptions := test_structure.LoadTerraformOptions(t, examplesDir)
@@ -124,8 +123,7 @@ func runNomadClusterSeparateTest(t *testing.T, packerBuildName string) {
 		awsRegion := getRandomRegion(t)
 		test_structure.SaveString(t, examplesDir, SAVED_AWS_REGION, awsRegion)
 
-		packerTemplatePath := filepath.Join(examplesDir, "nomad-consul-ami", "nomad-consul.json")
-		amiId := buildAmi(t, packerTemplatePath, packerBuildName, awsRegion)
+		amiId := buildAmi(t, filepath.Join(examplesDir, "examples", "nomad-consul-ami", "nomad-consul.json"), packerBuildName, awsRegion)
 		test_structure.SaveAmiId(t, examplesDir, amiId)
 	})
 
@@ -135,7 +133,7 @@ func runNomadClusterSeparateTest(t *testing.T, packerBuildName string) {
 		uniqueId := random.UniqueId()
 
 		terraformOptions := &terraform.Options{
-			TerraformDir: filepath.Join(examplesDir, "nomad-consul-separate-cluster"),
+			TerraformDir: examplesDir,
 			Vars: map[string]interface{}{
 				CLUSTER_SEPARATE_EXAMPLE_VAR_NOMAD_CLUSTER_NAME:  fmt.Sprintf("test-%s", uniqueId),
 				CLUSTER_SEPARATE_EXAMPLE_VAR_CONSUL_CLUSTER_NAME: fmt.Sprintf("test-%s", uniqueId),

--- a/test/nomad_helpers.go
+++ b/test/nomad_helpers.go
@@ -39,8 +39,6 @@ const CLUSTER_SEPARATE_EXAMPLE_OUTPUT_NOMAD_SERVER_ASG_NAME = "asg_name_nomad_se
 const DEFAULT_NUM_SERVERS = 3
 const DEFAULT_NUM_CLIENTS = 6
 
-// const AMI_EXAMPLE_PATH = "../examples/nomad-consul-ami/nomad-consul.json"
-
 const SAVED_AWS_REGION = "AwsRegion"
 
 // Test the Nomad/Consul colocated cluster example by:

--- a/test/nomad_helpers.go
+++ b/test/nomad_helpers.go
@@ -133,7 +133,7 @@ func runNomadClusterSeparateTest(t *testing.T, packerBuildName string) {
 		uniqueId := random.UniqueId()
 
 		terraformOptions := &terraform.Options{
-			TerraformDir: examplesDir,
+			TerraformDir: filepath.Join(examplesDir, "examples", "nomad-consul-separate-cluster"),
 			Vars: map[string]interface{}{
 				CLUSTER_SEPARATE_EXAMPLE_VAR_NOMAD_CLUSTER_NAME:  fmt.Sprintf("test-%s", uniqueId),
 				CLUSTER_SEPARATE_EXAMPLE_VAR_CONSUL_CLUSTER_NAME: fmt.Sprintf("test-%s", uniqueId),

--- a/test/nomad_helpers.go
+++ b/test/nomad_helpers.go
@@ -135,7 +135,7 @@ func runNomadClusterSeparateTest(t *testing.T, packerBuildName string) {
 		uniqueId := random.UniqueId()
 
 		terraformOptions := &terraform.Options{
-			TerraformDir: examplesDir,
+			TerraformDir: filepath.Join(examplesDir, "nomad-consul-separate-cluster"),
 			Vars: map[string]interface{}{
 				CLUSTER_SEPARATE_EXAMPLE_VAR_NOMAD_CLUSTER_NAME:  fmt.Sprintf("test-%s", uniqueId),
 				CLUSTER_SEPARATE_EXAMPLE_VAR_CONSUL_CLUSTER_NAME: fmt.Sprintf("test-%s", uniqueId),

--- a/variables.tf
+++ b/variables.tf
@@ -22,7 +22,7 @@
 variable "ami_id" {
   description = "The ID of the AMI to run in the cluster. This should be an AMI built from the Packer template under examples/nomad-consul-ami/nomad-consul.json. If no AMI is specified, the template will 'just work' by using the example public AMIs. WARNING! Do not use the example AMIs in a production setting!"
   type        = string
-  default     = ""
+  default     = null
 }
 
 variable "cluster_name" {

--- a/variables.tf
+++ b/variables.tf
@@ -21,45 +21,55 @@
 
 variable "ami_id" {
   description = "The ID of the AMI to run in the cluster. This should be an AMI built from the Packer template under examples/nomad-consul-ami/nomad-consul.json. If no AMI is specified, the template will 'just work' by using the example public AMIs. WARNING! Do not use the example AMIs in a production setting!"
+  type=string
   default     = ""
 }
 
 variable "cluster_name" {
   description = "What to name the cluster and all of its associated resources"
+  type=string
   default     = "nomad-example"
 }
 
 variable "instance_type" {
   description = "What kind of instance type to use for the nomad clients"
+  type=string
   default     = "t2.micro"
 }
 
 variable "num_servers" {
   description = "The number of server nodes to deploy. We strongly recommend using 3 or 5."
+  type=number
   default     = 3
 }
 
 variable "num_clients" {
   description = "The number of client nodes to deploy. You can deploy as many as you need to run your jobs."
+  type=number
   default     = 6
 }
 
 variable "cluster_tag_key" {
   description = "The tag the EC2 Instances will look for to automatically discover each other and form a cluster."
+  type=string
   default     = "nomad-servers"
 }
 
 variable "cluster_tag_value" {
   description = "Add a tag with key var.cluster_tag_key and this value to each Instance in the ASG. This can be used to automatically find other Consul nodes and form a cluster."
+  type=string
   default     = "auto-join"
 }
 
 variable "ssh_key_name" {
   description = "The name of an EC2 Key Pair that can be used to SSH to the EC2 Instances in this cluster. Set to an empty string to not associate a Key Pair."
+  type=string
   default     = ""
 }
 
 variable "vpc_id" {
   description = "The ID of the VPC in which the nodes will be deployed.  Uses default VPC if not supplied."
+  type=string
   default     = ""
 }
+

--- a/variables.tf
+++ b/variables.tf
@@ -21,55 +21,55 @@
 
 variable "ami_id" {
   description = "The ID of the AMI to run in the cluster. This should be an AMI built from the Packer template under examples/nomad-consul-ami/nomad-consul.json. If no AMI is specified, the template will 'just work' by using the example public AMIs. WARNING! Do not use the example AMIs in a production setting!"
-  type=string
+  type        = string
   default     = ""
 }
 
 variable "cluster_name" {
   description = "What to name the cluster and all of its associated resources"
-  type=string
+  type        = string
   default     = "nomad-example"
 }
 
 variable "instance_type" {
   description = "What kind of instance type to use for the nomad clients"
-  type=string
+  type        = string
   default     = "t2.micro"
 }
 
 variable "num_servers" {
   description = "The number of server nodes to deploy. We strongly recommend using 3 or 5."
-  type=number
+  type        = number
   default     = 3
 }
 
 variable "num_clients" {
   description = "The number of client nodes to deploy. You can deploy as many as you need to run your jobs."
-  type=number
+  type        = number
   default     = 6
 }
 
 variable "cluster_tag_key" {
   description = "The tag the EC2 Instances will look for to automatically discover each other and form a cluster."
-  type=string
+  type        = string
   default     = "nomad-servers"
 }
 
 variable "cluster_tag_value" {
   description = "Add a tag with key var.cluster_tag_key and this value to each Instance in the ASG. This can be used to automatically find other Consul nodes and form a cluster."
-  type=string
+  type        = string
   default     = "auto-join"
 }
 
 variable "ssh_key_name" {
   description = "The name of an EC2 Key Pair that can be used to SSH to the EC2 Instances in this cluster. Set to an empty string to not associate a Key Pair."
-  type=string
+  type        = string
   default     = ""
 }
 
 variable "vpc_id" {
   description = "The ID of the VPC in which the nodes will be deployed.  Uses default VPC if not supplied."
-  type=string
+  type        = string
   default     = ""
 }
 


### PR DESCRIPTION
This PR makes all modules and examples compatible with Terraform 0.12.x. Also upgraded tests to use terratest version to 0.17.4

Please note that this change is BACKWARDS INCOMPATIBLE and you MUST use Terraform 0.12.x and above with the code once this has been merged.
