### PR TITLE
update variable min/max to single variable

### DIFF
--- a/examples/nomad-consul-separate-cluster/main.tf
+++ b/examples/nomad-consul-separate-cluster/main.tf
@@ -165,18 +165,13 @@ module "nomad_clients" {
   source = "../../modules/nomad-cluster"
 
   cluster_name  = "${var.nomad_cluster_name}-client"
+  cluster_size  = var.num_clients
   instance_type = "t2.micro"
 
   # Give the clients a different tag so they don't try to join the server cluster
   cluster_tag_key   = "nomad-clients"
   cluster_tag_value = var.nomad_cluster_name
 
-  # To keep the example simple, we are using a fixed-size cluster. In real-world usage, you could use auto scaling
-  # policies to dynamically resize the cluster in response to load.
-
-  min_size         = var.num_nomad_clients
-  max_size         = var.num_nomad_clients
-  desired_capacity = var.num_nomad_clients
   ami_id           = var.ami_id == null ? data.aws_ami.nomad_consul.image_id : var.ami_id
   user_data        = data.template_file.user_data_nomad_client.rendered
   vpc_id           = data.aws_vpc.default.id

--- a/examples/nomad-consul-separate-cluster/main.tf
+++ b/examples/nomad-consul-separate-cluster/main.tf
@@ -67,12 +67,8 @@ module "nomad_servers" {
   source = "../../modules/nomad-cluster"
 
   cluster_name  = "${var.nomad_cluster_name}-server"
+  cluster_size  = var.num_nomad_servers
   instance_type = "t2.micro"
-
-  # You should typically use a fixed size of 3 or 5 for your Nomad server cluster
-  min_size         = var.num_nomad_servers
-  max_size         = var.num_nomad_servers
-  desired_capacity = var.num_nomad_servers
 
   ami_id    = var.ami_id == null ? data.aws_ami.nomad_consul.image_id : var.ami_id
   user_data = data.template_file.user_data_nomad_server.rendered

--- a/main.tf
+++ b/main.tf
@@ -135,18 +135,12 @@ module "clients" {
   source = "./modules/nomad-cluster"
 
   cluster_name  = "${var.cluster_name}-client"
+  cluster_size  = var.num_servers
   instance_type = var.instance_type
 
   # Give the clients a different tag so they don't try to join the server cluster
   cluster_tag_key   = "nomad-clients"
   cluster_tag_value = var.cluster_name
-
-  # To keep the example simple, we are using a fixed-size cluster. In real-world usage, you could use auto scaling
-  # policies to dynamically resize the cluster in response to load.
-  min_size = var.num_clients
-
-  max_size         = var.num_clients
-  desired_capacity = var.num_clients
 
   ami_id    = var.ami_id == null ? data.aws_ami.nomad_consul.image_id : var.ami_id
   user_data = data.template_file.user_data_client.rendered

--- a/main.tf
+++ b/main.tf
@@ -135,7 +135,7 @@ module "clients" {
   source = "./modules/nomad-cluster"
 
   cluster_name  = "${var.cluster_name}-client"
-  cluster_size  = var.num_servers
+  cluster_size  = var.num_clients
   instance_type = var.instance_type
 
   # Give the clients a different tag so they don't try to join the server cluster

--- a/modules/nomad-cluster/main.tf
+++ b/modules/nomad-cluster/main.tf
@@ -58,6 +58,7 @@ resource "aws_launch_configuration" "launch_configuration" {
   image_id      = var.ami_id
   instance_type = var.instance_type
   user_data     = var.user_data
+  spot_price    = var.spot_price
 
   iam_instance_profile = aws_iam_instance_profile.instance_profile.name
   key_name             = var.ssh_key_name

--- a/modules/nomad-cluster/main.tf
+++ b/modules/nomad-cluster/main.tf
@@ -17,9 +17,9 @@ resource "aws_autoscaling_group" "autoscaling_group" {
   availability_zones  = var.availability_zones
   vpc_zone_identifier = var.subnet_ids
 
-  min_size             = var.min_size
-  max_size             = var.max_size
-  desired_capacity     = var.desired_capacity
+  min_size             = var.cluster_size
+  max_size             = var.cluster_size
+  desired_capacity     = var.cluster_size
   termination_policies = [var.termination_policies]
 
   health_check_type         = var.health_check_type

--- a/modules/nomad-cluster/variables.tf
+++ b/modules/nomad-cluster/variables.tf
@@ -105,9 +105,9 @@ variable "spot_price" {
 }
 
 variable "tenancy" {
-  description = "The tenancy of the instance. Must be one of: default or dedicated."
+  description = "The tenancy of the instance. Must be one of: null, default or dedicated. For EC2 Spot Instances only null or dedicated can be used."
   type        = string
-  default     = "default"
+  default     = null
 }
 
 variable "root_volume_ebs_optimized" {

--- a/modules/nomad-cluster/variables.tf
+++ b/modules/nomad-cluster/variables.tf
@@ -33,20 +33,10 @@ variable "user_data" {
   type        = string
 }
 
-variable "min_size" {
-  description = "The minimum number of nodes to have in the cluster. If you're using this to run Nomad servers, we strongly recommend setting this to 3 or 5."
+variable "cluster_size" {
+  description = "The number of nodes to have in the Nomad cluster. We strongly recommended that you use either 3 or 5."
   type        = number
-}
-
-variable "max_size" {
-  description = "The maximum number of nodes to have in the cluster. If you're using this to run Nomad servers, we strongly recommend setting this to 3 or 5."
-  type        = number
-}
-
-variable "desired_capacity" {
-  description = "The desired number of nodes to have in the cluster. If you're using this to run Nomad servers, we strongly recommend setting this to 3 or 5."
-  type        = number
-}
+  default     = 3
 
 # ---------------------------------------------------------------------------------------------------------------------
 # OPTIONAL PARAMETERS

--- a/modules/nomad-cluster/variables.tf
+++ b/modules/nomad-cluster/variables.tf
@@ -97,6 +97,12 @@ variable "associate_public_ip_address" {
   default     = false
 }
 
+variable "spot_price" {
+  description = "The maximum hourly price to pay for EC2 Spot Instances."
+  type        = number
+  default     = null
+}
+
 variable "tenancy" {
   description = "The tenancy of the instance. Must be one of: default or dedicated."
   type        = string

--- a/modules/nomad-cluster/variables.tf
+++ b/modules/nomad-cluster/variables.tf
@@ -37,6 +37,7 @@ variable "cluster_size" {
   description = "The number of nodes to have in the Nomad cluster. We strongly recommended that you use either 3 or 5."
   type        = number
   default     = 3
+}
 
 # ---------------------------------------------------------------------------------------------------------------------
 # OPTIONAL PARAMETERS


### PR DESCRIPTION
Given the repeatability of the cluster size changing to a single value to also maintain coherence with the consul module seems like a good idea.