### PR TITLE
[nomad-security-group-rules] allow empty list of allowed inbound CIDRs

### DIFF
--- a/modules/nomad-security-group-rules/main.tf
+++ b/modules/nomad-security-group-rules/main.tf
@@ -11,6 +11,7 @@ terraform {
 }
 
 resource "aws_security_group_rule" "allow_http_inbound" {
+  count       = length(var.allowed_inbound_cidr_blocks) >= 1 ? 1 : 0
   type        = "ingress"
   from_port   = var.http_port
   to_port     = var.http_port
@@ -21,6 +22,7 @@ resource "aws_security_group_rule" "allow_http_inbound" {
 }
 
 resource "aws_security_group_rule" "allow_rpc_inbound" {
+  count       = length(var.allowed_inbound_cidr_blocks) >= 1 ? 1 : 0
   type        = "ingress"
   from_port   = var.rpc_port
   to_port     = var.rpc_port
@@ -31,6 +33,7 @@ resource "aws_security_group_rule" "allow_rpc_inbound" {
 }
 
 resource "aws_security_group_rule" "allow_serf_tcp_inbound" {
+  count       = length(var.allowed_inbound_cidr_blocks) >= 1 ? 1 : 0
   type        = "ingress"
   from_port   = var.serf_port
   to_port     = var.serf_port
@@ -41,6 +44,7 @@ resource "aws_security_group_rule" "allow_serf_tcp_inbound" {
 }
 
 resource "aws_security_group_rule" "allow_serf_udp_inbound" {
+  count       = length(var.allowed_inbound_cidr_blocks) >= 1 ? 1 : 0
   type        = "ingress"
   from_port   = var.serf_port
   to_port     = var.serf_port


### PR DESCRIPTION
Issue https://github.com/hashicorp/terraform-aws-nomad/issues/59

The error is caused by trying to create a SG rule with 0 CIDRs.

Error produced in terraform:
```
Error: One of ['cidr_blocks', 'ipv6_cidr_blocks', 'self', 'source_security_group_id', 'prefix_list_ids'] must be set to create an AWS Security Group Rule
```

This pull request brings the nomad module inline with how the Vault and Consul modules handle this. The addition of toggling count when there are no CIDRs will prevent the SG rules from being created and causing an error. There should be no backwards compatibility issues or downtime.