### PR TITLE
Fix missing snapshot id in ebs devices in nomad cluster

### DIFF
--- a/modules/nomad-cluster/main.tf
+++ b/modules/nomad-cluster/main.tf
@@ -83,6 +83,7 @@ resource "aws_launch_configuration" "launch_configuration" {
     content {
       device_name           = ebs_block_device.value["device_name"]
       volume_size           = ebs_block_device.value["volume_size"]
+      snapshot_id           = lookup(ebs_block_device.value, "snapshot_id", null)
       iops                  = lookup(ebs_block_device.value, "iops", null)
       encrypted             = lookup(ebs_block_device.value, "encrypted", null)
       delete_on_termination = lookup(ebs_block_device.value, "delete_on_termination", null)


### PR DESCRIPTION
If the volume_size is 0 then we assume that a snapshotid is available and use that one instead.
AWS requires either a volume size or a snapshotid.
It seems that Terraform filters a volume size of 0 out of the request to AWS.

https://github.com/hashicorp/terraform-aws-nomad/issues/63