### PR TITLE
Enable Docker in Amazon Linux 2 AMI example

### DIFF
--- a/examples/nomad-consul-ami/setup_amazon-linux-2.sh
+++ b/examples/nomad-consul-ami/setup_amazon-linux-2.sh
@@ -8,5 +8,6 @@ sudo yum install -y git
 
 echo "[INFO] [${SCRIPT}] Setup docker"
 sudo yum install -y docker
-sudo service docker start
+sudo systemctl enable docker
+sudo systemctl start docker
 sudo usermod -a -G docker ec2-user


### PR DESCRIPTION
After #62, Docker no longer starts on startup when creating an instance from the example AMI, thus Nomad isn't able to use Docker as a driver.