### PR TITLE
Add instance scale-in protection for nomad-cluster

### DIFF
--- a/modules/nomad-cluster/main.tf
+++ b/modules/nomad-cluster/main.tf
@@ -26,6 +26,8 @@ resource "aws_autoscaling_group" "autoscaling_group" {
   health_check_grace_period = var.health_check_grace_period
   wait_for_capacity_timeout = var.wait_for_capacity_timeout
 
+  protect_from_scale_in = var.protect_from_scale_in
+
   tag {
     key                 = "Name"
     value               = var.cluster_name

--- a/modules/nomad-cluster/variables.tf
+++ b/modules/nomad-cluster/variables.tf
@@ -222,3 +222,9 @@ variable "ebs_block_devices" {
   # ]
 }
 
+variable "protect_from_scale_in" {
+  description = "(Optional) Allows setting instance protection. The autoscaling group will not select instances with this setting for termination during scale in events."
+  type        = bool
+  default     = false
+}
+


### PR DESCRIPTION
This change solve issue: https://github.com/hashicorp/terraform-aws-nomad/issues/70

The changes are tested with an existing nomad-cluster without scale-in protection. The optional scale-in protection is set to true.
The terraform plan output is here:
https://gist.github.com/mawa-jnd/1f1ee3c744f9c38718527c240a5d9475

The change is:
- backward compatible
- has no downtime with default setup as changing the ASG will not automatically restart instances


