### PR TITLE
Use instance type from variable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -64,7 +64,7 @@ module "servers" {
 
   cluster_name  = "${var.cluster_name}-server"
   cluster_size  = var.num_servers
-  instance_type = var.instance_type
+  instance_type = var.server_instance_type
 
   # The EC2 Instances will use these tags to automatically discover each other and form a cluster
   cluster_tag_key   = var.cluster_tag_key

--- a/main.tf
+++ b/main.tf
@@ -64,7 +64,7 @@ module "servers" {
 
   cluster_name  = "${var.cluster_name}-server"
   cluster_size  = var.num_servers
-  instance_type = "t2.micro"
+  instance_type = var.instance_type
 
   # The EC2 Instances will use these tags to automatically discover each other and form a cluster
   cluster_tag_key   = var.cluster_tag_key

--- a/variables.tf
+++ b/variables.tf
@@ -37,6 +37,13 @@ variable "instance_type" {
   default     = "t2.micro"
 }
 
+variable "server_instance_type" {
+  description = "What kind of instance type to use for the nomad server"
+  type        = string
+  default     = "t2.micro"
+}
+
+
 variable "num_servers" {
   description = "The number of server nodes to deploy. We strongly recommend using 3 or 5."
   type        = number


### PR DESCRIPTION
The servers use a hard coded instance type, of `t2.micro`. Added the variable `server_instance_type` and set the variable default to `t2.micro`.