### PR TITLE
:fire: Fixes #92 Remove misleading cluster  join information

### DIFF
--- a/examples/nomad-consul-separate-cluster/main.tf
+++ b/examples/nomad-consul-separate-cluster/main.tf
@@ -173,7 +173,6 @@ module "nomad_clients" {
   cluster_name  = "${var.nomad_cluster_name}-client"
   instance_type = "t2.micro"
 
-  # Give the clients a different tag so they don't try to join the server cluster
   cluster_tag_key   = "nomad-clients"
   cluster_tag_value = var.nomad_cluster_name
 

--- a/modules/run-nomad/run-nomad
+++ b/modules/run-nomad/run-nomad
@@ -322,16 +322,6 @@ function run {
         user="$2"
         shift
         ;;
-      --cluster-tag-key)
-        assert_not_empty "$key" "$2"
-        cluster_tag_key="$2"
-        shift
-        ;;
-      --cluster-tag-value)
-        assert_not_empty "$key" "$2"
-        cluster_tag_value="$2"
-        shift
-        ;;
       --skip-nomad-config)
         skip_nomad_config="true"
         ;;


### PR DESCRIPTION
* Removes misleading comment in examples
* Removes misleading mention of Consul clustering in the variable description
* Removes unused CLI flags from `run-nomad`