### PR TITLE
ARM64 support + Version bumps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,8 @@ jobs:
       # AMI already in the AWS Account.
       - run: _ci/publish-amis.sh "ubuntu16-ami"
       - run: _ci/publish-amis.sh "ubuntu18-ami"
-      - run: _ci/publish-amis.sh "amazon-linux-2-ami"
+      - run: _ci/publish-amis.sh "amazon-linux-2-amd64-ami"
+      - run: _ci/publish-amis.sh "amazon-linux-2-arm64-ami"
 workflows:
   version: 2
   build-and-test:

--- a/examples/nomad-consul-ami/nomad-consul-docker.json
+++ b/examples/nomad-consul-ami/nomad-consul-docker.json
@@ -2,15 +2,15 @@
   "min_packer_version": "0.12.0",
   "variables": {
     "aws_region": "us-east-1",
-    "nomad_version": "0.9.1",
-    "consul_module_version": "v0.8.0",
-    "consul_version": "1.5.1",
+    "nomad_version": "1.1.1",
+    "consul_module_version": "v0.10.1",
+    "consul_version": "1.9.6",
     "ami_name_prefix": "nomad-consul"
   },
   "builders": [
     {
       "name": "ubuntu18-ami",
-      "ami_name": "{{user `ami_name_prefix`}}-docker-ubuntu18-{{isotime | clean_ami_name}}",
+      "ami_name": "{{user `ami_name_prefix`}}-docker-ubuntu18-{{isotime | clean_resource_name}}",
       "ami_description": "An example of how to build an Ubuntu 18.04 AMI that has Nomad, Consul and Docker",
       "instance_type": "t2.micro",
       "region": "{{user `aws_region`}}",
@@ -32,7 +32,7 @@
     },
     {
       "name": "ubuntu16-ami",
-      "ami_name": "{{user `ami_name_prefix`}}-docker-ubuntu16-{{isotime | clean_ami_name}}",
+      "ami_name": "{{user `ami_name_prefix`}}-docker-ubuntu16-{{isotime | clean_resource_name}}",
       "ami_description": "An Ubuntu 16.04 AMI that has Nomad, Consul and Docker installed.",
       "instance_type": "t2.micro",
       "region": "{{user `aws_region`}}",
@@ -53,16 +53,38 @@
       "ssh_username": "ubuntu"
     },
     {
-      "ami_name": "{{user `ami_name_prefix`}}-docker-amazon-linux-2-{{isotime | clean_ami_name}}",
-      "ami_description": "An Amazon Linux 2 AMI that has Nomad, Consul and Docker installed.",
+      "ami_name": "{{user `ami_name_prefix`}}-docker-amazon-linux-2-amd64-{{isotime | clean_resource_name}}",
+      "ami_description": "An Amazon Linux 2 x86_64 AMI that has Nomad, Consul and Docker installed.",
       "instance_type": "t2.micro",
-      "name": "amazon-linux-2-ami",
+      "name": "amazon-linux-2-amd64-ami",
       "region": "{{user `aws_region`}}",
       "type": "amazon-ebs",
       "source_ami_filter": {
         "filters": {
           "virtualization-type": "hvm",
           "architecture": "x86_64",
+          "name": "*amzn2-ami-hvm-*",
+          "block-device-mapping.volume-type": "gp2",
+          "root-device-type": "ebs"
+        },
+        "owners": [
+          "amazon"
+        ],
+        "most_recent": true
+      },
+      "ssh_username": "ec2-user"
+    },
+    {
+      "ami_name": "{{user `ami_name_prefix`}}-docker-amazon-linux-2-arm64-{{isotime | clean_resource_name}}",
+      "ami_description": "An Amazon Linux 2 ARM64 AMI that has Nomad, Consul and Docker installed.",
+      "instance_type": "t4g.micro",
+      "name": "amazon-linux-2-arm64-ami",
+      "region": "{{user `aws_region`}}",
+      "type": "amazon-ebs",
+      "source_ami_filter": {
+        "filters": {
+          "virtualization-type": "hvm",
+          "architecture": "arm64",
           "name": "*amzn2-ami-hvm-*",
           "block-device-mapping.volume-type": "gp2",
           "root-device-type": "ebs"
@@ -92,7 +114,8 @@
       "type": "shell",
       "script": "{{template_dir}}/setup_amazon-linux-2.sh",
       "only": [
-        "amazon-linux-2-ami"
+        "amazon-linux-2-amd64-ami",
+        "amazon-linux-2-arm64-ami"
       ]
     },
     {

--- a/examples/nomad-consul-ami/nomad-consul.json
+++ b/examples/nomad-consul-ami/nomad-consul.json
@@ -2,9 +2,9 @@
   "min_packer_version": "0.12.0",
   "variables": {
     "aws_region": "us-east-1",
-    "nomad_version": "0.9.1",
-    "consul_module_version": "v0.8.0",
-    "consul_version": "1.5.1",
+    "nomad_version": "1.1.1",
+    "consul_module_version": "v0.10.1",
+    "consul_version": "1.9.6",
     "ami_name_prefix": "nomad-consul"
   },
   "builders": [
@@ -53,16 +53,38 @@
       "ssh_username": "ubuntu"
     },
     {
-      "ami_name": "{{user `ami_name_prefix`}}-amazon-linux-2-{{isotime | clean_resource_name}}",
-      "ami_description": "An Amazon Linux 2 AMI that has Nomad and Consul installed.",
+      "ami_name": "{{user `ami_name_prefix`}}-amazon-linux-2-amd64-{{isotime | clean_resource_name}}",
+      "ami_description": "An Amazon Linux 2 x86_64 AMI that has Nomad and Consul installed.",
       "instance_type": "t2.micro",
-      "name": "amazon-linux-2-ami",
+      "name": "amazon-linux-2-amd64-ami",
       "region": "{{user `aws_region`}}",
       "type": "amazon-ebs",
       "source_ami_filter": {
         "filters": {
           "virtualization-type": "hvm",
           "architecture": "x86_64",
+          "name": "*amzn2-ami-hvm-*",
+          "block-device-mapping.volume-type": "gp2",
+          "root-device-type": "ebs"
+        },
+        "owners": [
+          "amazon"
+        ],
+        "most_recent": true
+      },
+      "ssh_username": "ec2-user"
+    },
+    {
+      "ami_name": "{{user `ami_name_prefix`}}-amazon-linux-2-arm64-{{isotime | clean_resource_name}}",
+      "ami_description": "An Amazon Linux 2 ARM64 AMI that has Nomad and Consul installed.",
+      "instance_type": "t4g.micro",
+      "name": "amazon-linux-2-arm64-ami",
+      "region": "{{user `aws_region`}}",
+      "type": "amazon-ebs",
+      "source_ami_filter": {
+        "filters": {
+          "virtualization-type": "hvm",
+          "architecture": "arm64",
           "name": "*amzn2-ami-hvm-*",
           "block-device-mapping.volume-type": "gp2",
           "root-device-type": "ebs"
@@ -92,7 +114,8 @@
         "sudo yum install -y git"
       ],
       "only": [
-        "amazon-linux-2-ami"
+        "amazon-linux-2-amd64-ami",
+        "amazon-linux-2-arm64-ami"
       ]
     },
     {

--- a/main.tf
+++ b/main.tf
@@ -64,7 +64,7 @@ module "servers" {
 
   cluster_name  = "${var.cluster_name}-server"
   cluster_size  = var.num_servers
-  instance_type = "t2.micro"
+  instance_type = var.server_instance_type
 
   # The EC2 Instances will use these tags to automatically discover each other and form a cluster
   cluster_tag_key   = var.cluster_tag_key

--- a/modules/install-nomad/install-nomad
+++ b/modules/install-nomad/install-nomad
@@ -127,8 +127,30 @@ function install_binaries {
   local readonly path="$2"
   local readonly username="$3"
 
-  local readonly url="https://releases.hashicorp.com/nomad/${version}/nomad_${version}_linux_amd64.zip"
-  local readonly download_path="/tmp/nomad_${version}_linux_amd64.zip"
+  local cpu_arch
+  cpu_arch="$(uname -m)"
+  local binary_arch=""
+  case "$cpu_arch" in
+    x86_64)
+      binary_arch="amd64"
+      ;;
+    x86)
+      binary_arch="386"
+      ;;
+    arm64|aarch64)
+      binary_arch="arm64"
+      ;;
+    arm*)
+      binary_arch="arm"
+      ;;
+    *)
+      log_error "CPU architecture $cpu_arch is not a supported by Consul."
+      exit 1
+      ;;
+    esac
+
+  local readonly url="https://releases.hashicorp.com/nomad/${version}/nomad_${version}_linux_${binary_arch}.zip"
+  local readonly download_path="/tmp/nomad_${version}_linux_${binary_arch}.zip"
   local readonly bin_dir="$path/bin"
   local readonly nomad_dest_path="$bin_dir/nomad"
   local readonly run_nomad_dest_path="$bin_dir/run-nomad"

--- a/test/nomad_cluster_ssh_test.go
+++ b/test/nomad_cluster_ssh_test.go
@@ -4,5 +4,5 @@ import "testing"
 
 func TestNomadClusterSSHAccess(t *testing.T) {
 	t.Parallel()
-	runNomadClusterSSHTest(t, "amazon-linux-2-ami", "ec2-user")
+	runNomadClusterSSHTest(t, "amazon-linux-2-amd64-ami", "ec2-user")
 }

--- a/test/nomad_consul_cluster_colocated_test.go
+++ b/test/nomad_consul_cluster_colocated_test.go
@@ -14,7 +14,7 @@ func TestNomadConsulClusterColocatedWithUbuntu16Ami(t *testing.T) {
 	runNomadClusterColocatedTest(t, "ubuntu16-ami")
 }
 
-func TestNomadConsulClusterColocatedAmazonLinux2Ami(t *testing.T) {
+func TestNomadConsulClusterColocatedAmazonLinux2Amd64Ami(t *testing.T) {
 	t.Parallel()
-	runNomadClusterColocatedTest(t, "amazon-linux-2-ami")
+	runNomadClusterColocatedTest(t, "amazon-linux-2-amd64-ami")
 }

--- a/test/nomad_consul_cluster_separate_test.go
+++ b/test/nomad_consul_cluster_separate_test.go
@@ -14,5 +14,5 @@ func TestNomadConsulClusterSeparateWithUbuntu16Ami(t *testing.T) {
 
 func TestNomadConsulClusterSeparateAmazonLinux2Ami(t *testing.T) {
 	t.Parallel()
-	runNomadClusterSeparateTest(t, "amazon-linux-2-ami")
+	runNomadClusterSeparateTest(t, "amazon-linux-2-amd64-ami")
 }

--- a/variables.tf
+++ b/variables.tf
@@ -31,6 +31,12 @@ variable "cluster_name" {
   default     = "nomad-example"
 }
 
+variable "server_instance_type" {
+  description = "What kind of instance type to use for the nomad servers"
+  type        = string
+  default     = "t2.micro"
+}
+
 variable "instance_type" {
   description = "What kind of instance type to use for the nomad clients"
   type        = string


### PR DESCRIPTION
Addresses feature request #80 and fixes issue #90 in the process. First time contribution so I could use help figuring out how to test this.

## Changes
* Split the amazon-linux-2-ami AMI into amazon-linux-2-amd64-ami and amazon-linux-2-arm64-ami
* Build ARM64 AMIs for Amazon Linux 2 for both docker + without docker
* Set server instance_type to a variable server_instance_type to allow for ARM64 support
* Nomad 0.9.1 -> 1.1.1
* Consul 1.5.1 -> 1.9.6
* Fix clean_ami_name deprecation with clean_resource_name