### PR TITLE
docs(*): fix releases links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,5 +89,5 @@ We require that all contributors sign our Contributor License Agreement ("CLA") 
 ## Merge and release   
 
 The maintainers for this repo will review your code and provide feedback. If everything looks good, they will merge the
-code and release a new version, which you'll be able to find in the [releases page](../../releases).
+code and release a new version, which you'll be able to find in the [releases page](https://github.com/hashicorp/terraform-aws-nomad/releases).
 

--- a/examples/nomad-consul-ami/README.md
+++ b/examples/nomad-consul-ami/README.md
@@ -75,7 +75,7 @@ Your code should look more like this:
 ```
 
 You should replace `<module_VERSION>` in the code above with the version of this module that you want to use (see
-the [Releases Page](../../releases) for all available versions). That's because for production usage, you should always
+the [Releases Page](https://github.com/hashicorp/terraform-aws-nomad/releases) for all available versions). That's because for production usage, you should always
 use a fixed, known version of this Module, downloaded from the official Git repo. On the other hand, when you're
 just experimenting with the Module, it's OK to use a local checkout of the Module, uploaded from your own
 computer.

--- a/modules/install-nomad/README.md
+++ b/modules/install-nomad/README.md
@@ -19,7 +19,7 @@ There is a good chance it will work on other flavors of Debian, CentOS, and RHEL
 
 <!-- TODO: update the clone URL to the final URL when this Module is released -->
 
-To install Nomad, use `git` to clone this repository at a specific tag (see the [releases page](../../../../releases)
+To install Nomad, use `git` to clone this repository at a specific tag (see the [releases page](https://github.com/hashicorp/terraform-aws-nomad/releases)
 for all available tags) and run the `install-nomad` script:
 
 ```


### PR DESCRIPTION
* Fixes the links to this repo's [releases page](https://github.com/hashicorp/terraform-aws-nomad/releases).  Perhaps at one time there was a `releases` directory at the top-level?  It doesn't appear to exist on `master` at time of writing...