### PR TITLE
corrected typo in run-nomad, bad keyword in generation of systemd config

### DIFF
--- a/modules/run-nomad/run-nomad
+++ b/modules/run-nomad/run-nomad
@@ -211,7 +211,7 @@ Description="HashiCorp Nomad"
 Documentation=https://www.nomadproject.io/
 Requires=network-online.target
 After=network-online.target
-ConditionalFileNotEmpty=$config_path
+ConditionFileNotEmpty=$config_path
 EOF
 )
 


### PR DESCRIPTION
The generated systemd config contained "ConditionalFileNotEmpty" in the [Unit], should be "ConditionFileNotEmpty".

## Description

Changed "ConditionalFileNotEmpty" to "ConditionFileNotEmpty".

### Documentation

Somple and obvious change, no backward incompatible changes.

## TODOs

Please ensure all of these TODOs are completed before asking for a review.

- [x] Ensure the branch is named correctly with the issue number. e.g: `feature/new-vpc-endpoints-955` or `bug/missing-count-param-434`.
- [x] Update the docs.
- [x] Keep the changes backward compatible where possible.
- [ ] Run the pre-commit checks successfully.
- [ ] Run the relevant tests successfully.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.


## Related Issues

[114](https://github.com/hashicorp/terraform-aws-nomad/issues/114).
